### PR TITLE
[UC06#59] Implemented RPC to get all physical cards of specific userDeck

### DIFF
--- a/src/main/java/com/aadm/cardexchange/server/CardServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/CardServiceImpl.java
@@ -39,6 +39,20 @@ public class CardServiceImpl extends RemoteServiceServlet implements CardService
         return new ArrayList<>(map.values());
     }
 
+    public String getNameCard(Game game, int idCard) {
+        if (game == null)
+            throw new IllegalArgumentException("game cannot be null");
+        if (idCard <= 0)
+            throw new IllegalArgumentException("Invalid cardId provided. cardId must be a positive integer greater than 0");
+        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getMapName(game),
+                Serializer.INTEGER, serializer);
+        try {
+            return map.get(idCard).getName();
+        } catch (Exception e) {
+            return "No Name";
+        }
+    }
+
     @Override
     public CardDecorator getGameCard(Game game, int cardId) {
         if (game == null)

--- a/src/main/java/com/aadm/cardexchange/server/CardServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/CardServiceImpl.java
@@ -24,7 +24,7 @@ public class CardServiceImpl extends RemoteServiceServlet implements CardService
         this.db = db;
     }
 
-    private String getMapName(Game game) {
+    public static String getCardMap(Game game) {
         return game == Game.Magic ? MAGIC_MAP_NAME :
                 game == Game.Pokemon ? POKEMON_MAP_NAME :
                         YUGIOH_MAP_NAME;
@@ -34,22 +34,16 @@ public class CardServiceImpl extends RemoteServiceServlet implements CardService
     public List<CardDecorator> getGameCards(Game game) {
         if (game == null)
             throw new IllegalArgumentException("game cannot be null");
-        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getMapName(game),
+        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getCardMap(game),
                 Serializer.INTEGER, serializer);
         return new ArrayList<>(map.values());
     }
 
-    public String getNameCard(Game game, int idCard) {
-        if (game == null)
-            throw new IllegalArgumentException("game cannot be null");
-        if (idCard <= 0)
-            throw new IllegalArgumentException("Invalid cardId provided. cardId must be a positive integer greater than 0");
-        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getMapName(game),
-                Serializer.INTEGER, serializer);
+    public static String getNameCard(Game game, int idCard, Map<Integer, CardDecorator> cardMap) {
         try {
-            return map.get(idCard).getName();
-        } catch (Exception e) {
-            return "No Name";
+            return cardMap.get(idCard).getName();
+        } catch (NullPointerException e) {
+            return "No Name Found";
         }
     }
 
@@ -59,7 +53,7 @@ public class CardServiceImpl extends RemoteServiceServlet implements CardService
             throw new IllegalArgumentException("game cannot be null");
         if (cardId <= 0)
             throw new IllegalArgumentException("Invalid cardId provided. cardId must be a positive integer greater than 0");
-        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getMapName(game),
+        Map<Integer, CardDecorator> map = db.getCachedMap(getServletContext(), getCardMap(game),
                 Serializer.INTEGER, serializer);
         return map.get(cardId);
     }

--- a/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
@@ -6,8 +6,7 @@ import com.google.gson.Gson;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 import org.mapdb.Serializer;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
 public class DeckServiceImpl extends RemoteServiceServlet implements DeckService, MapDBConstants {
@@ -91,4 +90,28 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         // physical card addition
         return foundDeck.addPhysicalCard(new PhysicalCardImpl(game, cardId, status, description));
     }
+
+    public List<PhysicalCardDecorator> getDecks (String token, String deckName) throws AuthException {
+        String userEmail = AuthServiceImpl.checkTokenValidity(token, db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
+        Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson));
+        Map<String, Deck> allUserDecks = deckMap.get(userEmail);
+        Deck thisUserDeck = allUserDecks.get(deckName);
+        List<PhysicalCardDecorator> pDecoratedCards;
+        for ( PhysicalCard physicalCard : thisUserDeck.getPhysicalCards()) {
+            CardDecorator.getStaticName(physicalCard.getCardId());
+            CardDecorator()
+
+        }
+
+
+        title = metodoStaticoPerPrendereIlTitoloDallaCartaVera(physicalCard.getCardId())
+        pDecoratedCards.add(physicalCard, title)
+
+        return pDecoratedCards;
+
+    }
+
+
+
+
 }

--- a/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
@@ -14,9 +14,9 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
     private final MapDB db;
     private final Gson gson = new Gson();
 
-    public DeckServiceImpl() {
-        db = new MapDBImpl();
-    }
+    private CardServiceImpl cardService;
+
+    public DeckServiceImpl() { db = new MapDBImpl(); }
 
     public DeckServiceImpl(MapDB mockDB) {
         db = mockDB;
@@ -91,27 +91,18 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         return foundDeck.addPhysicalCard(new PhysicalCardImpl(game, cardId, status, description));
     }
 
-    public List<PhysicalCardDecorator> getDecks (String token, String deckName) throws AuthException {
+    @Override
+    public List<PhysicalCardDecorator> getDeckByName(String token, String deckName) throws AuthException {
         String userEmail = AuthServiceImpl.checkTokenValidity(token, db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
         Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson));
         Map<String, Deck> allUserDecks = deckMap.get(userEmail);
         Deck thisUserDeck = allUserDecks.get(deckName);
-        List<PhysicalCardDecorator> pDecoratedCards;
+        List<PhysicalCardDecorator> pDecoratedCards = new ArrayList<>();
         for ( PhysicalCard physicalCard : thisUserDeck.getPhysicalCards()) {
-            CardDecorator.getStaticName(physicalCard.getCardId());
-            CardDecorator()
-
-        }
-
-
-        title = metodoStaticoPerPrendereIlTitoloDallaCartaVera(physicalCard.getCardId())
-        pDecoratedCards.add(physicalCard, title)
-
+            String cardName = cardService.getNameCard(physicalCard.getGameType(), physicalCard.getCardId());
+            PhysicalCardDecorator thisPhysicalDecoratorCard = new PhysicalCardDecorator(new PhysicalCardImpl(physicalCard.getGameType(), physicalCard.getCardId(), physicalCard.getStatus(), physicalCard.getDescription()), cardName);
+            pDecoratedCards.add(thisPhysicalDecoratorCard);
+            }
         return pDecoratedCards;
-
     }
-
-
-
-
 }

--- a/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/DeckServiceImpl.java
@@ -14,8 +14,6 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
     private final MapDB db;
     private final Gson gson = new Gson();
 
-    private CardServiceImpl cardService;
-
     public DeckServiceImpl() { db = new MapDBImpl(); }
 
     public DeckServiceImpl(MapDB mockDB) {
@@ -99,8 +97,17 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         Deck thisUserDeck = allUserDecks.get(deckName);
         List<PhysicalCardDecorator> pDecoratedCards = new ArrayList<>();
         for ( PhysicalCard physicalCard : thisUserDeck.getPhysicalCards()) {
-            String cardName = cardService.getNameCard(physicalCard.getGameType(), physicalCard.getCardId());
-            PhysicalCardDecorator thisPhysicalDecoratorCard = new PhysicalCardDecorator(new PhysicalCardImpl(physicalCard.getGameType(), physicalCard.getCardId(), physicalCard.getStatus(), physicalCard.getDescription()), cardName);
+            System.out.println(physicalCard.getCardId());
+            String cardName = CardServiceImpl.getNameCard(
+                    physicalCard.getGameType(),
+                    physicalCard.getCardId(),
+                    db.getCachedMap(
+                            getServletContext(),
+                            CardServiceImpl.getCardMap(physicalCard.getGameType()),
+                            Serializer.INTEGER,
+                            new GsonSerializer<>(gson)));
+            PhysicalCardDecorator thisPhysicalDecoratorCard = new PhysicalCardDecorator(
+                    new PhysicalCardImpl(physicalCard.getGameType(), physicalCard.getCardId(), physicalCard.getStatus(), physicalCard.getDescription()), cardName);
             pDecoratedCards.add(thisPhysicalDecoratorCard);
             }
         return pDecoratedCards;

--- a/src/main/java/com/aadm/cardexchange/shared/DeckService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckService.java
@@ -13,7 +13,7 @@ public interface DeckService extends RemoteService {
 
     boolean addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description) throws AuthException;
 
-    List<PhysicalCardDecorator> getDecks(String token) throws AuthException;
+    List<PhysicalCardDecorator> getDeckByName(String token, String deckName) throws AuthException;
 
 
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckService.java
@@ -1,10 +1,10 @@
 package com.aadm.cardexchange.shared;
 
-import com.aadm.cardexchange.shared.models.AuthException;
-import com.aadm.cardexchange.shared.models.Game;
-import com.aadm.cardexchange.shared.models.Status;
+import com.aadm.cardexchange.shared.models.*;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+import java.util.List;
 
 @RemoteServiceRelativePath("decks")
 public interface DeckService extends RemoteService {
@@ -12,4 +12,8 @@ public interface DeckService extends RemoteService {
     boolean addDeck(String token, String deckName) throws AuthException;
 
     boolean addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description) throws AuthException;
+
+    List<PhysicalCardDecorator> getDecks(String token) throws AuthException;
+
+
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -12,5 +12,5 @@ public interface DeckServiceAsync {
 
     void addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description, AsyncCallback<Boolean> callback);
 
-    void getDecks(String token, AsyncCallback<List<PhysicalCardDecorator>> async);
+    void getDeckByName(String token, String deckName, AsyncCallback<List<PhysicalCardDecorator>> async);
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -1,11 +1,16 @@
 package com.aadm.cardexchange.shared;
 
 import com.aadm.cardexchange.shared.models.Game;
+import com.aadm.cardexchange.shared.models.PhysicalCardDecorator;
 import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import java.util.List;
 
 public interface DeckServiceAsync {
     void addDeck(String email, String deckName, AsyncCallback<Boolean> callback);
 
     void addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description, AsyncCallback<Boolean> callback);
+
+    void getDecks(String token, AsyncCallback<List<PhysicalCardDecorator>> async);
 }

--- a/src/main/java/com/aadm/cardexchange/shared/models/CardDecorator.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/CardDecorator.java
@@ -26,6 +26,8 @@ public class CardDecorator implements Card {
         return wrapped.getName();
     }
 
+    public static String getStaticName(int id) {return  .getName();}
+
     @Override
     public String getDescription() {
         return wrapped.getDescription();

--- a/src/main/java/com/aadm/cardexchange/shared/models/CardDecorator.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/CardDecorator.java
@@ -26,7 +26,7 @@ public class CardDecorator implements Card {
         return wrapped.getName();
     }
 
-    public static String getStaticName(int id) {return  .getName();}
+   // public static String getStaticName(int id) {return  .getName();}
 
     @Override
     public String getDescription() {

--- a/src/test/java/com/aadm/cardexchange/server/CardServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/CardServiceTest.java
@@ -14,6 +14,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -102,4 +103,11 @@ public class CardServiceTest {
         ctrl.verify();
         Assertions.assertEquals(expectedMap.get(2), actualCard);
     }
+
+    @Test
+    public void testGetNameCard(){
+        Assertions.assertEquals("No Name Found", CardServiceImpl.getNameCard(Game.Magic, 1111, new HashMap<>()));
+    }
+
+
 }

--- a/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
@@ -314,8 +314,14 @@ public class DeckServiceTest {
         //deckService.addPhysicalCardToDeck("validToken", Game.Magic, "Owned", 111, Status.Excellent, "This is a valid description.");
 
         ctrl.replay();
-        Assertions.assertEquals(new ArrayList<>(mockDeckMap.values()), deckService.getDeckByName("validToken", "Owned"));
+        //Assertions.assertArrayEquals(ArrayList<>(deckMap.values()), deckService.getDeckByName("validToken", "Owned"));
+        List<PhysicalCardDecorator> decoratedCards = deckService.getDeckByName("validToken", "Owned");
         ctrl.verify();
-        Assertions.assertEquals(new ArrayList<>(expectedMap.values()), cards);        ctrl.verify();
+        Assertions.assertAll(() -> {
+            Assertions.assertEquals(2, decoratedCards.size());
+            Assertions.assertEquals("Nome1", decoratedCards.get(0).getName());
+            Assertions.assertEquals("Nome2", decoratedCards.get(1).getName());
+
+        });
     }
 }


### PR DESCRIPTION
This PR implements #59, adding the necessary RPC for  return all physical cards of a specific user deck. 
There are two major methods: first is "getDeckByName" in "DeckServiceImpl" and the second one is getNameCard in CardServiceImpl, for providing less information about card name used in first method.
Supplied with coverage for unit testing.