### PR TITLE
[UC05#57] Implemented modal referred to 'AddToDeck' button  in Card Details Page to allow users to add the card to a selected deck

### DIFF
--- a/src/main/java/com/aadm/cardexchange/CardExchange.gwt.xml
+++ b/src/main/java/com/aadm/cardexchange/CardExchange.gwt.xml
@@ -13,9 +13,9 @@
     <!-- Inherit the default GWT style sheet.  You can change       -->
     <!-- the theme of your GWT application by uncommenting          -->
     <!-- any one of the following lines.                            -->
-    <!--  <inherits name='com.google.gwt.user.theme.clean.Clean'/>-->
-    <inherits name='com.google.gwt.user.theme.standard.Standard'/>
-    <!-- <inherits name='com.google.gwt.user.theme.chrome.Chrome'/> -->
+    <!-- <inherits name='com.google.gwt.user.theme.clean.Clean'/>    -->
+    <!-- <inherits name='com.google.gwt.user.theme.standard.Standard'/>  -->
+     <inherits name='com.google.gwt.user.theme.chrome.Chrome'/>
     <!-- <inherits name='com.google.gwt.user.theme.dark.Dark'/>     -->
 
     <!-- Other module inherits                                      -->

--- a/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
@@ -6,21 +6,27 @@ import com.aadm.cardexchange.client.places.CardPlace;
 import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.CardView;
 import com.aadm.cardexchange.shared.CardServiceAsync;
+import com.aadm.cardexchange.shared.DeckServiceAsync;
+import com.aadm.cardexchange.shared.models.AuthException;
 import com.aadm.cardexchange.shared.models.CardDecorator;
+import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
 public class CardActivity extends AbstractActivity implements CardView.Presenter, Observer {
     private final CardPlace place;
     private final CardView view;
-    private final CardServiceAsync rpcService;
+    private final CardServiceAsync cardService;
+    private final DeckServiceAsync deckService;
     private final AuthSubject authSubject;
 
-    public CardActivity(CardPlace place, CardView view, CardServiceAsync rpcService, AuthSubject authSubject) {
+    public CardActivity(CardPlace place, CardView view, CardServiceAsync cardService, DeckServiceAsync deckService, AuthSubject authSubject) {
         this.place = place;
         this.view = view;
-        this.rpcService = rpcService;
+        this.cardService = cardService;
+        this.deckService = deckService;
         this.authSubject = authSubject;
         authSubject.attach(this);
     }
@@ -39,11 +45,39 @@ public class CardActivity extends AbstractActivity implements CardView.Presenter
     }
 
     public void fetchCard() {
-        rpcService.getGameCard(place.getGame(), place.getCardId(), new BaseAsyncCallback<CardDecorator>() {
+        cardService.getGameCard(place.getGame(), place.getCardId(), new BaseAsyncCallback<CardDecorator>() {
             @Override
             public void onSuccess(CardDecorator result) {
                 view.setData(result);
             }
         });
+    }
+
+    public void addCardToDeck(String deckName, String status, String description) {
+        deckService.addPhysicalCardToDeck(
+                authSubject.getToken(),
+                place.getGame(),
+                deckName,
+                place.getCardId(),
+                Status.getStatus(Integer.parseInt(status)),
+                description,
+                new AsyncCallback<Boolean>() {
+                    @Override
+                    public void onFailure(Throwable caught) {
+                        if (caught instanceof AuthException) {
+                            view.displayErrorAlert(((AuthException) caught).getErrorMessage());
+                        } else if (caught instanceof IllegalArgumentException) {
+                            view.displayErrorAlert(caught.getMessage());
+                        } else {
+                            view.displayErrorAlert(caught.getMessage());
+                        }
+                    }
+                    @Override
+                    public void onSuccess(Boolean result) {
+                        view.displaySuccessAlert();
+                        view.hideModal();
+                    }
+                }
+        );
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
@@ -74,8 +74,12 @@ public class CardActivity extends AbstractActivity implements CardView.Presenter
                     }
                     @Override
                     public void onSuccess(Boolean result) {
-                        view.displaySuccessAlert();
-                        view.hideModal();
+                        if (result) {
+                            view.displaySuccessAlert();
+                            view.hideModal();
+                        } else {
+                            view.displayErrorAlert("Deck not found.");
+                        }
                     }
                 }
         );

--- a/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
+++ b/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
@@ -11,6 +11,7 @@ import com.aadm.cardexchange.client.presenters.DecksActivity;
 import com.aadm.cardexchange.client.presenters.HomeActivity;
 import com.aadm.cardexchange.shared.AuthService;
 import com.aadm.cardexchange.shared.CardService;
+import com.aadm.cardexchange.shared.DeckService;
 import com.google.gwt.activity.shared.Activity;
 import com.google.gwt.activity.shared.ActivityMapper;
 import com.google.gwt.core.client.GWT;
@@ -28,7 +29,7 @@ public class AppActivityMapper implements ActivityMapper {
         if (place instanceof HomePlace)
             return new HomeActivity(clientFactory.getHomeView(), GWT.create(CardService.class), clientFactory.getPlaceController());
         if (place instanceof CardPlace)
-            return new CardActivity((CardPlace) place, clientFactory.getCardView(), GWT.create(CardService.class), clientFactory.getAuthSubject());
+            return new CardActivity((CardPlace) place, clientFactory.getCardView(), GWT.create(CardService.class), GWT.create(DeckService.class), clientFactory.getAuthSubject());
         if (place instanceof AuthPlace)
             return new AuthActivity(clientFactory.getAuthView(), GWT.create(AuthService.class), clientFactory.getAuthSubject(), clientFactory.getPlaceController());
         if (place instanceof DecksPlace)

--- a/src/main/java/com/aadm/cardexchange/client/views/CardView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardView.java
@@ -5,10 +5,14 @@ import com.google.gwt.user.client.ui.IsWidget;
 
 public interface CardView extends IsWidget {
     void setData(CardDecorator data);
+    void hideModal();
+    void displayErrorAlert(String errorMessage);
+    void displaySuccessAlert();
     void createUserWidgets(boolean isLoggedIn);
     void setPresenter(Presenter presenter);
 
     interface Presenter {
         void fetchCard();
+        void addCardToDeck(String deckName, String status, String description);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
@@ -1,7 +1,6 @@
 package com.aadm.cardexchange.client.views;
 
-import com.aadm.cardexchange.client.widgets.AddCardToDeckWidget;
-import com.aadm.cardexchange.client.widgets.UserListWidget;
+import com.aadm.cardexchange.client.widgets.*;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
@@ -9,12 +8,10 @@ import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.HTMLPanel;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.*;
 
-public class CardViewImpl extends Composite implements CardView {
+public class CardViewImpl extends Composite implements CardView, ImperativeHandleAddCardToDeck, ImperativeHandleAddCardToDeckModal {
     private static final CardsViewImplUIBinder uiBinder = GWT.create(CardsViewImplUIBinder.class);
     @UiField
     SpanElement cardGame;
@@ -63,6 +60,8 @@ public class CardViewImpl extends Composite implements CardView {
     @UiField
     HTMLPanel userLists;
     Presenter presenter;
+    AddCardToDeckWidget addCardToDeckWidget = new AddCardToDeckWidget(this);
+    DialogBox dialog = new AddCardToDeckModalWidget(this);
 
     public CardViewImpl() {
         initWidget(uiBinder.createAndBindUi(this));
@@ -152,7 +151,9 @@ public class CardViewImpl extends Composite implements CardView {
         addCardToDeckContainer.clear();
         userLists.clear();
         // create AddCartToDeckWidget
-        if (isLoggedIn) addCardToDeckContainer.add(new AddCardToDeckWidget());
+        if (isLoggedIn) {
+            addCardToDeckContainer.add(addCardToDeckWidget);
+        }
         // create UserListWidget 'Exchange' buttons
         userLists.add(new UserListWidget(
                 "Owned by",
@@ -160,7 +161,7 @@ public class CardViewImpl extends Composite implements CardView {
                 isLoggedIn
         ));
         userLists.add(new UserListWidget(
-                "Desired by",
+                "Wished by",
                 new String[]{"matteo.sacco04@studio.unibo.it"},
                 isLoggedIn));
     }
@@ -168,6 +169,45 @@ public class CardViewImpl extends Composite implements CardView {
     @Override
     public void setPresenter(Presenter presenter) {
         this.presenter = presenter;
+    }
+
+    @Override
+    public void onClickAddToDeck() {
+        dialog.center();
+        dialog.setModal(true);
+        dialog.show();
+        if (addCardToDeckWidget.getDeckName().equals("Owned")) {
+            dialog.setText("Do you own this card?");
+        } else if(addCardToDeckWidget.getDeckName().equals("Wished")) {
+            dialog.setText("Do you wish this card?");
+        } else {
+            dialog.setText("YOU MUST SELECT A DECK!");
+        }
+    }
+
+    @Override
+    public void hideModal() {
+        dialog.hide();
+    }
+
+    @Override
+    public void onClickModalNo() {
+        hideModal();
+    }
+
+    @Override
+    public void onClickModalYes(String status, String description) {
+        presenter.addCardToDeck(addCardToDeckWidget.getDeckName(), status, description);
+    }
+
+    @Override
+    public void displayErrorAlert(String errorMessage) {
+        Window.alert(errorMessage);
+    }
+
+    @Override
+    public void displaySuccessAlert() {
+        Window.alert("Success! Card added to " + addCardToDeckWidget.getDeckName() + " deck");
     }
 
     interface CardsViewImplUIBinder extends UiBinder<Widget, CardViewImpl> {

--- a/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.ui.xml
@@ -9,7 +9,7 @@
             display: flex;
             flex: 1;
             flex-direction: column;
-            gap: 1.5rem;
+            justify-content: space-around;
         }
 
         .detailsGrid {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
@@ -1,0 +1,38 @@
+package com.aadm.cardexchange.client.widgets;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.*;
+
+public class AddCardToDeckModalWidget extends DialogBox {
+    @UiField
+    ListBox status;
+    @UiField
+    TextArea description;
+    @UiField
+    Button noButton;
+    @UiField
+    Button yesButton;
+    private static final AddCardToDeckModalUiBinder uiBinder = GWT.create(AddCardToDeckModalUiBinder.class);
+
+    public AddCardToDeckModalWidget(ImperativeHandleAddCardToDeckModal parent) {
+        setWidget(uiBinder.createAndBindUi(this));
+        setAutoHideEnabled(true);
+        setModal(true);
+        setAnimationEnabled(true);
+        setGlassEnabled(true);
+        noButton.addClickHandler(clickEvent -> parent.onClickModalNo());
+        yesButton.addClickHandler(clickEvent -> parent.onClickModalYes(status.getSelectedValue(), description.getValue()));
+    }
+
+    @Override
+    public void hide() {
+        status.setItemSelected(0, true);
+        description.setText("");
+        super.hide();
+    }
+
+    interface AddCardToDeckModalUiBinder extends UiBinder<Widget, AddCardToDeckModalWidget> {
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.ui.xml
@@ -1,0 +1,69 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+    <ui:style>
+        .modal {
+            border-radius: 1rem;
+            border: 2px solid black;
+        }
+
+        .background {
+            display: flex;
+            flex-direction: column;
+            gap: 1.2rem;
+        }
+
+        .field {
+        }
+
+        .status {
+            color: black;
+        }
+
+        .descriptionArea {
+            width: 12rem;
+            height: 5rem;
+            resize: none;
+        }
+
+        .actions {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+        }
+
+        .button {
+            border-radius: 0;
+            border: 2px solid black;
+        }
+
+        .button:hover {
+            background-color: #CCCCCC;
+        }
+
+        .noButton {
+            border-bottom-left-radius: 1rem;
+        }
+
+        .yesButton {
+            border-bottom-right-radius: 1rem;
+        }
+    </ui:style>
+    <g:DialogBox styleName="{style.modal}">
+        <g:HTMLPanel styleName="{style.background}">
+            <div class="{style.field}">State
+                <g:ListBox styleName="{style.status}" ui:field='status'>
+                    <g:item value="1">1 - VeryDamaged</g:item>
+                    <g:item value="2">2 - Damaged</g:item>
+                    <g:item value="3">3 - Fair</g:item>
+                    <g:item value="4">4 - Good</g:item>
+                    <g:item value="5">5 - Excellent</g:item>
+                </g:ListBox>
+            </div>
+            <div class="{style.field}">Description<g:TextArea styleName="{style.descriptionArea}" ui:field='description'/></div>
+            <div class="{style.actions}">
+                <g:Button styleName="{style.button} {style.noButton}" ui:field='noButton'>No</g:Button>
+                <g:Button styleName="{style.button} {style.yesButton}" ui:field='yesButton'>Yes</g:Button>
+            </div>
+        </g:HTMLPanel>
+    </g:DialogBox>
+</ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.java
@@ -2,16 +2,28 @@ package com.aadm.cardexchange.client.widgets;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.PushButton;
 import com.google.gwt.user.client.ui.Widget;
 
 public class AddCardToDeckWidget extends Composite {
-    private static final AddCardToDeckWidgetUiBinder addCardTODeckUiBinder = GWT.create(AddCardToDeckWidgetUiBinder.class);
+    private static final AddCardToDeckUiBinder uiBinder = GWT.create(AddCardToDeckUiBinder.class);
+    @UiField
+    PushButton addToDeckButton;
+    @UiField
+    ListBox deckListBox;
 
-    public AddCardToDeckWidget() {
-        initWidget(addCardTODeckUiBinder.createAndBindUi(this));
+    public AddCardToDeckWidget(ImperativeHandleAddCardToDeck parent) {
+        initWidget(uiBinder.createAndBindUi(this));
+        addToDeckButton.addClickHandler(clickEvent -> parent.onClickAddToDeck());
     }
 
-    interface AddCardToDeckWidgetUiBinder extends UiBinder<Widget, AddCardToDeckWidget> {
+    public String getDeckName() {
+        return deckListBox.getSelectedValue();
+    }
+
+    interface AddCardToDeckUiBinder extends UiBinder<Widget, AddCardToDeckWidget> {
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.ui.xml
@@ -12,12 +12,11 @@
         }
     </ui:style>
     <g:HTMLPanel styleName="{style.addCardToDeck}">
-        <select name="deck">
-            <option value="">-- select a deck --</option>
-            <option value="owned">Owned</option>
-            <option value="desired">Desired</option>
-            <option value="custom">Custom 1</option>
-        </select>
+        <g:ListBox ui:field="deckListBox">
+            <g:item value="">-- select a deck --</g:item>
+            <g:item value="Owned">Owned</g:item>
+            <g:item value="Wished">Wished</g:item>
+        </g:ListBox>
         <g:PushButton addStyleNames="{style.deckButton}" ui:field="addToDeckButton">Add to deck</g:PushButton>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandleAddCardToDeck.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandleAddCardToDeck.java
@@ -1,0 +1,5 @@
+package com.aadm.cardexchange.client.widgets;
+
+public interface ImperativeHandleAddCardToDeck {
+    void onClickAddToDeck();
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandleAddCardToDeckModal.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandleAddCardToDeckModal.java
@@ -1,0 +1,6 @@
+package com.aadm.cardexchange.client.widgets;
+
+public interface ImperativeHandleAddCardToDeckModal {
+    void onClickModalNo();
+    void onClickModalYes(String status, String description);
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
@@ -18,7 +18,8 @@ public class UserListWidget extends Composite {
     FlexTable table;
     boolean showExchangeButton;
 
-    @UiConstructor public UserListWidget(String title, String[] users, boolean showExchangeButton) {
+    @UiConstructor
+    public UserListWidget(String title, String[] users, boolean showExchangeButton) {
         this.showExchangeButton = showExchangeButton;
         setupTable();
         initWidget(uiBinder.createAndBindUi(this));

--- a/src/main/java/com/aadm/cardexchange/shared/models/Status.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/Status.java
@@ -11,4 +11,13 @@ public enum Status {
     public int getValue() {
         return value;
     }
+
+    public static Status getStatus(int value) {
+        return value == 1 ? VeryDamaged :
+                value == 2 ? Damaged :
+                        value == 3 ? Fair :
+                                value == 4 ? Good :
+                                        value == 5 ? Excellent :
+                                                null;
+    }
 }


### PR DESCRIPTION
This PR implements #57 adding a modal to CardView `AddToDeck` button in which users should insert the properties of their physical card (status and description) in order to add this card to their 'Owned' or 'Wished' deck.

Coverage with unit testing has been done.