### PR TITLE

[UC09#91] Implemented RPC to save exchange proposal on DB

### DIFF
--- a/src/main/java/com/aadm/cardexchange/server/mapdb/MapDBConstants.java
+++ b/src/main/java/com/aadm/cardexchange/server/mapdb/MapDBConstants.java
@@ -10,4 +10,5 @@ public interface MapDBConstants {
     String DECK_MAP_NAME = "DECK_MAP";
     String USER_MAP_NAME = "USER_MAP";
     String LOGIN_MAP_NAME = "LOGIN_MAP";
+    String PROPOSAL_MAP_NAME = "PROPOSAL_MAP";
 }

--- a/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
@@ -24,16 +24,12 @@ public class ExchangeServiceImpl extends RemoteServiceServlet implements Exchang
     private static final long serialVersionUID = 5868088467963819042L;
     private final MapDB db;
     private final Gson gson = new Gson();
-    private final Type type = new TypeToken<Map<Integer, Proposal>>() {
-    }.getType();
     public ExchangeServiceImpl() {
         db = new MapDBImpl();
     }
-
     public ExchangeServiceImpl(MapDB mockDB) {
         db = mockDB;
     }
-
     private boolean checkEmailExistance(String email) {
         Map<String, User> userMap = db.getPersistentMap(
                 getServletContext(), USER_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson));
@@ -50,7 +46,6 @@ public class ExchangeServiceImpl extends RemoteServiceServlet implements Exchang
     public boolean addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards) throws AuthException, InputException {
         String email = AuthServiceImpl.checkTokenValidity(token,
                 db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
-        //System.out.println(email);
         if (receiverUserEmail == null || receiverUserEmail.isEmpty() || !checkEmailExistance(receiverUserEmail)) {
             throw new InputException("Invalid receiverUserEmail name");
         } else if (!checkPcardListConsistency(senderPhysicalCards)) {
@@ -59,7 +54,7 @@ public class ExchangeServiceImpl extends RemoteServiceServlet implements Exchang
             throw new InputException("Invalid senderPhysicalCards list");
         } else {
             Proposal newProposal = new Proposal(email, receiverUserEmail, senderPhysicalCards, receiverPhysicalCards);
-            Map<Integer, Proposal> proposalMap = db.getPersistentMap(getServletContext(), PROPOSAL_MAP_NAME, Serializer.INTEGER, new GsonSerializer<>(gson, type));
+            Map<Integer, Proposal> proposalMap = db.getPersistentMap(getServletContext(), PROPOSAL_MAP_NAME, Serializer.INTEGER, new GsonSerializer<>(gson));
             if (proposalMap.putIfAbsent(newProposal.getId(), newProposal) == null) return true;
             else return false;
         }

--- a/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
@@ -1,0 +1,51 @@
+package com.aadm.cardexchange.server.services;
+
+import com.aadm.cardexchange.server.gsonserializer.GsonSerializer;
+import com.aadm.cardexchange.server.mapdb.MapDB;
+import com.aadm.cardexchange.server.mapdb.MapDBConstants;
+import com.aadm.cardexchange.server.mapdb.MapDBImpl;
+import com.aadm.cardexchange.shared.DeckService;
+import com.aadm.cardexchange.shared.ExchangeService;
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.InputException;
+import com.aadm.cardexchange.shared.models.*;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import org.mapdb.Serializer;
+
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static com.aadm.cardexchange.server.services.AuthServiceImpl.validateEmail;
+
+
+public class ExchangeServiceImpl extends RemoteServiceServlet implements ExchangeService, MapDBConstants {
+    private static final long serialVersionUID = 5868088467963819042L;
+    private final MapDB db;
+    private final Gson gson = new Gson();
+
+    public ExchangeServiceImpl() {
+        db = new MapDBImpl();
+    }
+
+    public ExchangeServiceImpl(MapDB mockDB) {
+        db = mockDB;
+    }
+/*
+    private static boolean addDeck(String email, String deckName, boolean isDefault, Map<String, Map<String, Deck>> deckMap) {
+        Map<String, Deck> userDecks = deckMap.computeIfAbsent(email, k -> new HashMap<>());
+        // if deck already exists in decks container do nothing
+        if (userDecks.get(deckName) != null) {
+            return false;
+        }
+        userDecks.put(deckName, new Deck(deckName, isDefault));
+        deckMap.put(email, userDecks);
+        return true;
+    }
+*/
+    @Override
+    public boolean addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards) throws AuthException {
+        return false;
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/shared/ExchangeService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/ExchangeService.java
@@ -2,6 +2,7 @@ package com.aadm.cardexchange.shared;
 
 import com.aadm.cardexchange.shared.exceptions.AuthException;
 import com.aadm.cardexchange.shared.exceptions.BaseException;
+import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.Game;
 import com.aadm.cardexchange.shared.models.PhysicalCardDecorator;
 import com.aadm.cardexchange.shared.models.PhysicalCardImpl;
@@ -14,6 +15,6 @@ import java.util.List;
 @RemoteServiceRelativePath("decks")
 public interface ExchangeService extends RemoteService {
 
-    boolean addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards) throws AuthException;
+    boolean addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards) throws AuthException, InputException;
 
 }

--- a/src/main/java/com/aadm/cardexchange/shared/ExchangeService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/ExchangeService.java
@@ -1,0 +1,19 @@
+package com.aadm.cardexchange.shared;
+
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.BaseException;
+import com.aadm.cardexchange.shared.models.Game;
+import com.aadm.cardexchange.shared.models.PhysicalCardDecorator;
+import com.aadm.cardexchange.shared.models.PhysicalCardImpl;
+import com.aadm.cardexchange.shared.models.Status;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+import java.util.List;
+
+@RemoteServiceRelativePath("decks")
+public interface ExchangeService extends RemoteService {
+
+    boolean addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards) throws AuthException;
+
+}

--- a/src/main/java/com/aadm/cardexchange/shared/ExchangeServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/ExchangeServiceAsync.java
@@ -1,0 +1,17 @@
+package com.aadm.cardexchange.shared;
+
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.BaseException;
+import com.aadm.cardexchange.shared.models.Game;
+import com.aadm.cardexchange.shared.models.PhysicalCardDecorator;
+import com.aadm.cardexchange.shared.models.PhysicalCardImpl;
+import com.aadm.cardexchange.shared.models.Status;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+import java.util.List;
+
+public interface ExchangeServiceAsync {
+    void addProposal(String token, String receiverUserEmail, List<PhysicalCardImpl> senderPhysicalCards, List<PhysicalCardImpl> receiverPhysicalCards, AsyncCallback<Boolean> async);
+}

--- a/src/main/java/com/aadm/cardexchange/shared/models/Game.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/Game.java
@@ -1,7 +1,21 @@
 package com.aadm.cardexchange.shared.models;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
 public enum Game {
     MAGIC,
     POKEMON,
-    YUGIOH
+    YUGIOH;
+
+    private static final List<Game> VALUES =
+            Collections.unmodifiableList(Arrays.asList(values()));
+    private static final int SIZE = VALUES.size();
+    private static final Random RANDOM = new Random();
+
+    public static Game randomGame()  {
+        return VALUES.get(RANDOM.nextInt(SIZE));
+    }
 }

--- a/src/main/java/com/aadm/cardexchange/shared/models/PhysicalCardImpl.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/PhysicalCardImpl.java
@@ -58,4 +58,13 @@ public class PhysicalCardImpl implements PhysicalCard {
     public int hashCode() {
         return Objects.hash(getId());
     }
+
+    @Override
+    public String toString() {
+        return "id: " + this.getId() +
+                ", cardID: " + this.getCardId() +
+                ", status: " + this.getStatus() +
+                ", description: " + this.getDescription() ;
+    }
+
 }

--- a/src/main/java/com/aadm/cardexchange/shared/models/Status.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/Status.java
@@ -1,5 +1,10 @@
 package com.aadm.cardexchange.shared.models;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
 public enum Status {
     VeryDamaged(1), Damaged(2), Fair(3), Good(4), Excellent(5);
     private final int value;
@@ -20,4 +25,12 @@ public enum Status {
                                         value == 5 ? Excellent :
                                                 null;
     }
+    private static final List<Status> VALUES =
+            Collections.unmodifiableList(Arrays.asList(values()));
+    private static final int SIZE = VALUES.size();
+    private static final Random RANDOM = new Random();
+    public static Status randomGame()  {
+        return VALUES.get(RANDOM.nextInt(SIZE));
+    }
+
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -18,6 +18,10 @@
         <servlet-name>com.aadm.cardexchange.CardExchange DeckService</servlet-name>
         <servlet-class>com.aadm.cardexchange.server.services.DeckServiceImpl</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>com.aadm.cardexchange.CardExchange ExchangeService</servlet-name>
+        <servlet-class>com.aadm.cardexchange.server.services.ExchangeServiceImpl</servlet-class>
+    </servlet>
     <servlet-mapping>
         <servlet-name>com.aadm.cardexchange.CardExchange CardService</servlet-name>
         <url-pattern>/cardexchange/cards</url-pattern>
@@ -29,6 +33,10 @@
     <servlet-mapping>
         <servlet-name>com.aadm.cardexchange.CardExchange DeckService</servlet-name>
         <url-pattern>/cardexchange/decks</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>com.aadm.cardexchange.CardExchange ExchangeService</servlet-name>
+        <url-pattern>/cardexchange/exchanges</url-pattern>
     </servlet-mapping>
 
     <listener>

--- a/src/test/java/com/aadm/cardexchange/CardExchangeSuite.java
+++ b/src/test/java/com/aadm/cardexchange/CardExchangeSuite.java
@@ -33,6 +33,7 @@ import org.junit.platform.suite.api.Suite;
         DeckServiceTest.class,
         ProposalTest.class,
         NewExchangePlaceTest.class,
+        ExchangeServiceTest.class,
 })
 public class CardExchangeSuite {
 }

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -63,17 +63,8 @@ public class ExchangeServiceTest {
             PhysicalCardImpl mockPCard = new PhysicalCardImpl(Game.randomGame(), (i+3000), Status.randomGame(), "This is a valid description.");
             myList.add(mockPCard);
         }
-        //System.out.println(myList.toString());
         return myList;
     }
-
-
-    /*
-    public void testGenerateValidListPcard() {
-
-        System.out.println((generateValidListPcard(10).toString()));
-    }
-    */
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"invalidToken"})
@@ -86,7 +77,6 @@ public class ExchangeServiceTest {
         expect(mockConfig.getServletContext()).andReturn(mockCtx);
         expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
                 .andReturn(loginInfoMap);
-        //setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(AuthException.class, () -> exchangeService.addProposal(input, "valid@receiverUserEmail.it", generateValidListPcard(2), generateValidListPcard(2)));
         ctrl.verify();
@@ -95,7 +85,6 @@ public class ExchangeServiceTest {
     @NullAndEmptySource
     public void testAddProposalForInvalidReceiverUserEmail(String input) {
         setupForValidToken();
-        //setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
             exchangeService.addProposal("validToken", input, generateValidListPcard(2), generateValidListPcard(2));
@@ -153,21 +142,6 @@ public class ExchangeServiceTest {
         });
         ctrl.verify();
     }
-
-    /*
-    @Test
-    public void testAddProposalForExistingProposal() throws AuthException, InputException {
-        setupForValidToken();
-        setupForValidEmail();
-        expect(mockConfig.getServletContext()).andReturn(mockCtx);
-        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
-                .andReturn(new HashMap<>());
-        ctrl.replay();
-        Assertions.assertTrue(exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(1), generateValidListPcard(2)));
-        ctrl.verify();
-    }
-    */
-
     @Test
     public void testAddProposalSuccess() throws AuthException, InputException {
         setupForValidToken();
@@ -179,5 +153,4 @@ public class ExchangeServiceTest {
         Assertions.assertTrue(exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(1), generateValidListPcard(2)));
         ctrl.verify();
     }
-
 }

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -83,7 +83,7 @@ public class ExchangeServiceTest {
         expect(mockConfig.getServletContext()).andReturn(mockCtx);
         expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
                 .andReturn(loginInfoMap);
-        setupForValidEmail();
+        //setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(AuthException.class, () -> exchangeService.addProposal(input, "valid@receiverUserEmail.it", generateValidListPcard(2), generateValidListPcard(2)));
         ctrl.verify();
@@ -92,7 +92,7 @@ public class ExchangeServiceTest {
     @NullAndEmptySource
     public void testAddProposalForInvalidReceiverUserEmail(String input) {
         setupForValidToken();
-        setupForValidEmail();
+        //setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
             exchangeService.addProposal("validToken", input, generateValidListPcard(2), generateValidListPcard(2));
@@ -110,13 +110,20 @@ public class ExchangeServiceTest {
         ctrl.verify();
     }
     @Test
-    public void testAddProposalForInvalidSenderPCards() throws AuthException {
+    public void testAddProposalForEmptySenderPCards() throws AuthException {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
-            exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(0), generateValidListPcard(2));
-        });
+                exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(0), generateValidListPcard(2));
+            });
+        ctrl.verify();
+    }
+    @Test
+    public void testAddProposalForNullSenderPCards() throws AuthException {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
             exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", null, generateValidListPcard(2));
         });
@@ -124,23 +131,47 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForInvalidReceiverPCards() throws AuthException {
+    public void testAddProposalForEmptyReceiverPCards() throws AuthException {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
             exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(2), generateValidListPcard(0));
         });
+        ctrl.verify();
+    }
+    @Test
+    public void testAddProposalForNullReceiverPCards() throws AuthException {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
         Assertions.assertThrows(InputException.class, () -> {
             exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(2), null);
         });
         ctrl.verify();
     }
 
+    /*
     @Test
-    public void testAddProposalSuccess() throws AuthException {
+    public void testAddProposalForExistingProposal() throws AuthException, InputException {
         setupForValidToken();
         setupForValidEmail();
+        expect(mockConfig.getServletContext()).andReturn(mockCtx);
+        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                .andReturn(new HashMap<>());
+        ctrl.replay();
+        Assertions.assertTrue(exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(1), generateValidListPcard(2)));
+        ctrl.verify();
+    }
+    */
+
+    @Test
+    public void testAddProposalSuccess() throws AuthException, InputException {
+        setupForValidToken();
+        setupForValidEmail();
+        expect(mockConfig.getServletContext()).andReturn(mockCtx);
+        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                .andReturn(new HashMap<>());
         ctrl.replay();
         Assertions.assertTrue(exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(1), generateValidListPcard(2)));
         ctrl.verify();

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -1,0 +1,149 @@
+package com.aadm.cardexchange.server;
+
+import com.aadm.cardexchange.server.mapdb.MapDB;
+import com.aadm.cardexchange.server.services.DeckServiceImpl;
+import com.aadm.cardexchange.server.services.ExchangeServiceImpl;
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.BaseException;
+import com.aadm.cardexchange.shared.exceptions.InputException;
+import com.aadm.cardexchange.shared.models.*;
+import org.easymock.IMocksControl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mapdb.Serializer;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.util.*;
+
+import static org.easymock.EasyMock.*;
+
+public class ExchangeServiceTest {
+    private IMocksControl ctrl;
+    private MapDB mockDB;
+    ServletConfig mockConfig;
+    ServletContext mockCtx;
+    private ExchangeServiceImpl exchangeService;
+
+    @BeforeEach
+    public void initialize() throws ServletException {
+        ctrl = createStrictControl();
+        mockDB = ctrl.createMock(MapDB.class);
+        exchangeService = new ExchangeServiceImpl(mockDB);
+        mockConfig = ctrl.createMock(ServletConfig.class);
+        mockCtx = ctrl.createMock(ServletContext.class);
+        exchangeService.init(mockConfig);
+    }
+
+    private void setupForValidToken() {
+        Map<String, LoginInfo> mockLoginMap = new HashMap<>() {{
+            put("validToken", new LoginInfo("test@test.it", System.currentTimeMillis() - 10000));
+        }};
+        expect(mockConfig.getServletContext()).andReturn(mockCtx);
+        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                .andReturn(mockLoginMap);
+    }
+    private void setupForValidEmail() {
+        Map<String, User> userMap = new HashMap<>();
+        userMap.put("valid@receiverUserEmail.it", new User("valid@receiverUserEmail.it", "password"));
+        expect(mockConfig.getServletContext()).andReturn(mockCtx);
+        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                .andReturn(userMap);
+    }
+    private  List<PhysicalCardImpl> generateValidListPcard(int n) {
+        List<PhysicalCardImpl> myList = new ArrayList<>();
+        for (int i = 0; i<n; i++ ) {
+            PhysicalCardImpl mockPCard = new PhysicalCardImpl(Game.randomGame(), (i+3000), Status.randomGame(), "This is a valid description.");
+            myList.add(mockPCard);
+        }
+        //System.out.println(myList.toString());
+        return myList;
+    }
+
+    @Test
+    public void testGenerateValidListPcard() {
+        System.out.println((generateValidListPcard(10).toString()));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"invalidToken"})
+    public void testAddProposalForInvalidToken(String input) {
+        Map<String, LoginInfo> loginInfoMap = new HashMap<>() {{
+            put("validToken1", new LoginInfo("test@test.it", System.currentTimeMillis() - 10000));
+            put("validToken2", new LoginInfo("test2@test.it", System.currentTimeMillis() - 20000));
+            put("validToken3", new LoginInfo("test3@test.it", System.currentTimeMillis() - 30000));
+        }};
+        expect(mockConfig.getServletContext()).andReturn(mockCtx);
+        expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                .andReturn(loginInfoMap);
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertThrows(AuthException.class, () -> exchangeService.addProposal(input, "valid@receiverUserEmail.it", generateValidListPcard(2), generateValidListPcard(2)));
+        ctrl.verify();
+    }
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testAddProposalForInvalidReceiverUserEmail(String input) {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", input, generateValidListPcard(2), generateValidListPcard(2));
+        });
+        ctrl.verify();
+    }
+    @Test
+    public void testAddProposalForNotExistingReceiverUserEmail() {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", "NotExisting@Mail.it", generateValidListPcard(2), generateValidListPcard(2));
+        });
+        ctrl.verify();
+    }
+    @Test
+    public void testAddProposalForInvalidSenderPCards() throws AuthException {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(0), generateValidListPcard(2));
+        });
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", null, generateValidListPcard(2));
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testAddProposalForInvalidReceiverPCards() throws AuthException {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(2), generateValidListPcard(0));
+        });
+        Assertions.assertThrows(InputException.class, () -> {
+            exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(2), null);
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testAddProposalSuccess() throws AuthException {
+        setupForValidToken();
+        setupForValidEmail();
+        ctrl.replay();
+        Assertions.assertTrue(exchangeService.addProposal("validToken", "valid@receiverUserEmail.it", generateValidListPcard(1), generateValidListPcard(2)));
+        ctrl.verify();
+    }
+
+}

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -8,6 +8,7 @@ import com.aadm.cardexchange.shared.exceptions.BaseException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.*;
 import org.easymock.IMocksControl;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,11 +67,13 @@ public class ExchangeServiceTest {
         return myList;
     }
 
-    @Test
+
+    /*
     public void testGenerateValidListPcard() {
+
         System.out.println((generateValidListPcard(10).toString()));
     }
-
+    */
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {"invalidToken"})


### PR DESCRIPTION
This PR implements #91, adding the necessary RPC ro create the proposal on DB. Minor change also for Status and Game class, adding a randomize method to improve quality of unit test.

Supplied with coverage for unit testing.