### PR TITLE
[UC17#148#149] Added functionality for users to add their own custom decks

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/CardExchange.java
+++ b/src/main/java/com/aadm/cardexchange/client/CardExchange.java
@@ -2,11 +2,11 @@ package com.aadm.cardexchange.client;
 
 import com.aadm.cardexchange.client.auth.AuthSubject;
 import com.aadm.cardexchange.client.auth.Observer;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleSidebar;
 import com.aadm.cardexchange.client.places.HomePlace;
 import com.aadm.cardexchange.client.routes.AppActivityMapper;
 import com.aadm.cardexchange.client.routes.AppPlaceHistoryMapper;
 import com.aadm.cardexchange.client.utils.IgnoreAsyncCallback;
-import com.aadm.cardexchange.client.widgets.ImperativeHandleSidebar;
 import com.aadm.cardexchange.client.widgets.SidebarWidget;
 import com.aadm.cardexchange.shared.AuthService;
 import com.aadm.cardexchange.shared.AuthServiceAsync;

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleAddCardToDeck.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleAddCardToDeck.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandleAddCardToDeck {
     void onClickAddToDeck();

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleAddCardToDeckModal.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleAddCardToDeckModal.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandleAddCardToDeckModal {
     void onClickModalYes(String status, String description);

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCard.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCard.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 import com.aadm.cardexchange.shared.models.Game;
 

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardRemove.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardRemove.java
@@ -4,8 +4,7 @@ import com.aadm.cardexchange.shared.models.PhysicalCard;
 
 import java.util.function.Consumer;
 
-public interface ImperativeHandlePhysicalCard {
-    void onChangeSelection();
-
+public interface ImperativeHandleCardRemove {
     void onClickDeleteButton(PhysicalCard pCard, Consumer<Boolean> isRemoved);
+
 }

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardSelection.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardSelection.java
@@ -1,0 +1,6 @@
+package com.aadm.cardexchange.client.handlers;
+
+public interface ImperativeHandleCardSelection {
+    void onChangeSelection();
+
+}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardsSelection.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardsSelection.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandleCardsSelection {
     void onChangeSelectedCards();

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeck.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeck.java
@@ -1,10 +1,14 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
+import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public interface ImperativeHandleDeck {
     void onShowDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData);
+
+    void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved);
 }

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCard.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCard.java
@@ -1,0 +1,11 @@
+package com.aadm.cardexchange.client.handlers;
+
+import com.aadm.cardexchange.shared.models.PhysicalCard;
+
+import java.util.function.Consumer;
+
+public interface ImperativeHandlePhysicalCard {
+    void onChangeSelection();
+
+    void onClickDeleteButton(PhysicalCard pCard, Consumer<Boolean> isRemoved);
+}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleSidebar.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleSidebar.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandleSidebar {
     void onClickLogout();

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleUserList.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleUserList.java
@@ -1,4 +1,4 @@
-package com.aadm.cardexchange.client.widgets;
+package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandleUserList {
     void onClickExchange(String receiverUserEmail, String selectedCardId);

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -4,13 +4,18 @@ import com.aadm.cardexchange.client.auth.AuthSubject;
 import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.DecksView;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.InputException;
+import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class DecksActivity extends AbstractActivity implements DecksView.Presenter {
     private final DecksView view;
@@ -41,6 +46,31 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
             @Override
             public void onSuccess(List<PhysicalCardWithName> result) {
                 setDeckData.accept(result, null);
+            }
+        });
+    }
+
+    @Override
+    public void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
+        if (deckName == null || deckName.isEmpty() || pCard == null) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
+        rpcService.removePhysicalCardFromDeck(authSubject.getToken(), deckName, pCard, new AsyncCallback<Boolean>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else if (caught instanceof InputException) {
+                    view.displayAlert(((InputException) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                isRemoved.accept(result);
             }
         });
     }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -40,6 +40,15 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
         view.resetData();
     }
 
+    private void fetchUserDeckNames() {
+        rpcService.getUserDeckNames(authSubject.getToken(), new BaseAsyncCallback<List<String>>() {
+            @Override
+            public void onSuccess(List<String> result) {
+                view.setData(result);
+            }
+        });
+    }
+
     @Override
     public void fetchUserDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData) {
         rpcService.getMyDeck(authSubject.getToken(), deckName, new BaseAsyncCallback<List<PhysicalCardWithName>>() {
@@ -50,10 +59,18 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
         });
     }
 
+    private boolean checkDeckNameInvalidity(String deckName) {
+        return deckName == null || deckName.isEmpty();
+    }
+
     @Override
     public void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
-        if (deckName == null || deckName.isEmpty() || pCard == null) {
+        if (checkDeckNameInvalidity(deckName)) {
             view.displayAlert("Invalid deck name");
+            return;
+        }
+        if (pCard == null) {
+            view.displayAlert("Invalid physical card");
             return;
         }
         rpcService.removePhysicalCardFromDeck(authSubject.getToken(), deckName, pCard, new AsyncCallback<Boolean>() {
@@ -75,12 +92,32 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
         });
     }
 
-    private void fetchUserDeckNames() {
-        rpcService.getUserDeckNames(authSubject.getToken(), new BaseAsyncCallback<List<String>>() {
+    @Override
+    public void createCustomDeck(String deckName) {
+        if (checkDeckNameInvalidity(deckName)) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
+
+        rpcService.addDeck(authSubject.getToken(), deckName, new AsyncCallback<Boolean>() {
             @Override
-            public void onSuccess(List<String> result) {
-                view.setData(result);
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                if (result) {
+                    view.displayAddedCustomDeck(deckName);
+                } else {
+                    view.displayAlert("deck already exists");
+                }
             }
         });
+
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
@@ -1,8 +1,13 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleAddCardToDeck;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleAddCardToDeckModal;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleUserList;
 import com.aadm.cardexchange.client.places.NewExchangePlace;
 import com.aadm.cardexchange.client.utils.DefaultImagePathLookupTable;
-import com.aadm.cardexchange.client.widgets.*;
+import com.aadm.cardexchange.client.widgets.AddCardToDeckModalWidget;
+import com.aadm.cardexchange.client.widgets.AddCardToDeckWidget;
+import com.aadm.cardexchange.client.widgets.UserListWidget;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -16,11 +16,15 @@ public interface DecksView extends IsWidget {
 
     void displayAlert(String message);
 
+    void displayAddedCustomDeck(String deckName);
+
     void setPresenter(Presenter presenter);
 
     interface Presenter {
         void fetchUserDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData);
 
         void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved);
+
+        void createCustomDeck(String deckName);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -1,10 +1,12 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public interface DecksView extends IsWidget {
 
@@ -12,9 +14,13 @@ public interface DecksView extends IsWidget {
 
     void resetData();
 
+    void displayAlert(String message);
+
     void setPresenter(Presenter presenter);
 
     interface Presenter {
         void fetchUserDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData);
+
+        void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -1,17 +1,20 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
-import com.aadm.cardexchange.client.widgets.ImperativeHandleDeck;
+import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
@@ -36,8 +39,18 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     }
 
     @Override
+    public void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
+        presenter.removePhysicalCardFromDeck(deckName, pCard, isRemoved);
+    }
+
+    @Override
     public void resetData() {
         decksContainer.clear();
+    }
+
+    @Override
+    public void displayAlert(String message) {
+        Window.alert(message);
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -5,8 +5,11 @@ import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.HeadingElement;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -18,9 +21,12 @@ import java.util.function.Consumer;
 
 public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
+    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your custom deck";
     Presenter presenter;
     @UiField
     HTMLPanel decksContainer;
+    @UiField
+    HeadingElement newDeckName;
 
     public DecksViewImpl() {
         initWidget(uiBinder.createAndBindUi(this));
@@ -51,6 +57,17 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     @Override
     public void displayAlert(String message) {
         Window.alert(message);
+    }
+
+    @Override
+    public void displayAddedCustomDeck(String deckName) {
+        decksContainer.add(new DeckWidget(this, null, deckName));
+        newDeckName.setInnerText(DEFAULT_CUSTOM_DECK_TEXT);
+    }
+
+    @UiHandler(value = "newDeckButton")
+    public void onClickCustomDeckAdd(ClickEvent e) {
+        presenter.createCustomDeck(newDeckName.getInnerText());
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-             xmlns:g="urn:import:com.google.gwt.user.client.ui"
-             xmlns:m="urn:import:com.aadm.cardexchange.client.widgets">
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
     <ui:style>
         .deckLayout {
             display: flex;
@@ -40,8 +39,8 @@
         <h1>User decks</h1>
         <g:HTMLPanel ui:field="decksContainer"/>
         <div class="{style.newDeck}">
-            <h2 contenteditable="true">Write here name for your custom deck</h2>
-            <g:Button styleName="{style.newDeckButton}">&#10003;</g:Button>
+            <h2 ui:field="newDeckName" contenteditable="true">Write here name for your custom deck</h2>
+            <g:Button ui:field="newDeckButton" styleName="{style.newDeckButton}">&#10003;</g:Button>
         </div>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/views/HomeViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/HomeViewImpl.java
@@ -1,9 +1,9 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCard;
 import com.aadm.cardexchange.client.places.CardPlace;
 import com.aadm.cardexchange.client.widgets.CardWidget;
 import com.aadm.cardexchange.client.widgets.GameFiltersWidget;
-import com.aadm.cardexchange.client.widgets.ImperativeHandleCard;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;

--- a/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
@@ -1,7 +1,7 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCardsSelection;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
-import com.aadm.cardexchange.client.widgets.ImperativeHandleCardsSelection;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -17,9 +17,9 @@ import java.util.List;
 public class NewExchangeViewImpl extends Composite implements NewExchangeView, ImperativeHandleCardsSelection {
     private static final NewExchangeViewImpl.NewExchangeViewImplUIBinder uiBinder = GWT.create(NewExchangeViewImpl.NewExchangeViewImplUIBinder.class);
     Presenter presenter;
-    @UiField(provided=true)
+    @UiField(provided = true)
     DeckWidget senderDeck;
-    @UiField(provided=true)
+    @UiField(provided = true)
     DeckWidget receiverDeck;
     @UiField
     Button cancelButton;

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleAddCardToDeckModal;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleAddCardToDeck;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;

--- a/src/main/java/com/aadm/cardexchange/client/widgets/CardWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/CardWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCard;
 import com.aadm.cardexchange.client.utils.DefaultImagePathLookupTable;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.gwt.core.client.GWT;

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -1,5 +1,8 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCardsSelection;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
+import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
@@ -14,6 +17,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class DeckWidget extends Composite implements ImperativeHandlePhysicalCard {
     private static final DeckUIBinder uiBinder = GWT.create(DeckUIBinder.class);
@@ -25,6 +29,7 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     Button showButton;
     boolean isVisible;
     List<PhysicalCard> deckSelectedCards;
+    ImperativeHandleDeck parent1;
     ImperativeHandleCardsSelection parent2;
 
     @UiConstructor
@@ -43,6 +48,7 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
                 cards.setVisible(isVisible);
             });
         }
+        this.parent1 = parent1;
         this.parent2 = parent2;
     }
 
@@ -79,7 +85,16 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     @Override
     public void onChangeSelection() {
         setDeckSelectedCards();
-        parent2.onChangeSelectedCards();
+        if (parent2 != null) {
+            parent2.onChangeSelectedCards();
+        }
+    }
+
+    @Override
+    public void onClickDeleteButton(PhysicalCard pCard, Consumer<Boolean> isRemoved) {
+        if (parent1 != null) {
+            parent1.onRemovePhysicalCard(deckName.getInnerText(), pCard, isRemoved);
+        }
     }
 
     interface DeckUIBinder extends UiBinder<Widget, DeckWidget> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandlePhysicalCard.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ImperativeHandlePhysicalCard.java
@@ -1,5 +1,0 @@
-package com.aadm.cardexchange.client.widgets;
-
-public interface ImperativeHandlePhysicalCard {
-    void onChangeSelection();
-}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
@@ -9,6 +10,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 
 public class PhysicalCardWidget extends Composite {
@@ -40,7 +42,13 @@ public class PhysicalCardWidget extends Composite {
 
         deleteButton.addClickHandler(e -> {
             e.stopPropagation();
-            this.removeFromParent();
+            if (Window.confirm("Are you sure you want to remove this card?")) {
+                parent.onClickDeleteButton(pCard, isRemoved -> {
+                    if (isRemoved != null && isRemoved) {
+                        this.removeFromParent();
+                    }
+                });
+            }
         });
 
         cardName.setInnerText(pCard.getName());
@@ -56,12 +64,17 @@ public class PhysicalCardWidget extends Composite {
         getElement().removeClassName(selected ? style.cardDiscarded() : style.cardSelected());
     }
 
-    public boolean getSelected() { return selected; }
+    public boolean getSelected() {
+        return selected;
+    }
 
-    public PhysicalCard getPhysicalCard() { return pCard; }
+    public PhysicalCard getPhysicalCard() {
+        return pCard;
+    }
 
     interface PhysicalCardStyle extends CssResource {
         String cardSelected();
+
         String cardDiscarded();
     }
 

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
@@ -1,12 +1,14 @@
 package com.aadm.cardexchange.client.widgets;
 
-import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCard;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCardRemove;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleCardSelection;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -26,30 +28,32 @@ public class PhysicalCardWidget extends Composite {
     DivElement cardStatus;
     @UiField
     DivElement cardDescription;
-    @UiField
-    Button deleteButton;
     boolean selected = false;
     PhysicalCardWithName pCard;
 
-    public PhysicalCardWidget(PhysicalCardWithName pCard, ImperativeHandlePhysicalCard parent) {
+    public PhysicalCardWidget(PhysicalCardWithName pCard, ImperativeHandleCardSelection selectionHandler, ImperativeHandleCardRemove removeHandler) {
         initWidget(uiBinder.createAndBindUi(this));
         cardContainer.add(new Hyperlink("Open Details",
                 "cards/" + pCard.getGameType() + "/" + pCard.getCardId()));
         cardContainer.addDomHandler(e -> {
             setSelected();
-            parent.onChangeSelection();
+            selectionHandler.onChangeSelection();
         }, ClickEvent.getType());
 
-        deleteButton.addClickHandler(e -> {
-            e.stopPropagation();
-            if (Window.confirm("Are you sure you want to remove this card?")) {
-                parent.onClickDeleteButton(pCard, isRemoved -> {
-                    if (isRemoved != null && isRemoved) {
-                        this.removeFromParent();
-                    }
-                });
-            }
-        });
+        if (removeHandler != null) {
+            Button deleteButton = new Button("X", (ClickHandler) e -> {
+                e.stopPropagation();
+                if (Window.confirm("Are you sure you want to remove this card?")) {
+                    removeHandler.onClickDeleteButton(pCard, isRemoved -> {
+                        if (isRemoved != null && isRemoved) {
+                            this.removeFromParent();
+                        }
+                    });
+                }
+            });
+            deleteButton.addStyleName(style.deleteButton());
+            cardContainer.add(deleteButton);
+        }
 
         cardName.setInnerText(pCard.getName());
         cardStatus.setInnerHTML(pCard.getStatus().name());
@@ -73,9 +77,12 @@ public class PhysicalCardWidget extends Composite {
     }
 
     interface PhysicalCardStyle extends CssResource {
+
         String cardSelected();
 
         String cardDiscarded();
+
+        String deleteButton();
     }
 
     interface PhysicalCardUiBinder extends UiBinder<Widget, PhysicalCardWidget> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.ui.xml
@@ -60,6 +60,5 @@
         <h2 ui:field="cardName"/>
         <div ui:field="cardDescription" class="{style.cardDescription}"/>
         <div ui:field="cardStatus" class="{style.cardStatus}"/>
-        <g:Button title="Rimuovi carta dal mazzo" styleName="{style.deleteButton}" ui:field="deleteButton">X</g:Button>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleSidebar;
 import com.aadm.cardexchange.client.routes.RouteConstants;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickHandler;

--- a/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
@@ -1,5 +1,6 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleUserList;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithEmail;
 import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.core.client.GWT;

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -6,7 +6,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import java.util.List;
 
 public interface DeckServiceAsync {
-    void addDeck(String email, String deckName, AsyncCallback<Boolean> callback);
+    void addDeck(String token, String deckName, AsyncCallback<Boolean> callback);
 
     void addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description, AsyncCallback<Boolean> callback);
 

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -5,6 +5,8 @@ import com.aadm.cardexchange.client.presenters.DecksActivity;
 import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.DecksView;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
+import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.Game;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
@@ -14,9 +16,15 @@ import org.easymock.IMocksControl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.easymock.EasyMock.*;
 
@@ -56,6 +64,68 @@ public class DecksActivityTest {
         });
         ctrl.replay();
         decksActivity.fetchUserDeck("Owned", Assertions::assertNotNull);
+        ctrl.verify();
+    }
+
+    private static Stream<Arguments> provideDifferentTypeOfErrors() {
+        return Stream.of(
+                Arguments.of(new AuthException("Invalid token")),
+                Arguments.of(new InputException("Invalid description")),
+                Arguments.of(new RuntimeException())
+        );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testRemovePhysicalCardFromDeckForInvalidDeckName(String input) {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.removePhysicalCardFromDeck(input, new PhysicalCard(Game.MAGIC, 111, Status.Good, "This is a valid description"), (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testRemovePhysicalCardFromDeckForNullPhysicalCard() {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.removePhysicalCardFromDeck("Owned", null, (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testRemovePhysicalCardFromDeckForFailure(Exception e) {
+        mockRpcService.removePhysicalCardFromDeck(anyString(), anyString(), isA(PhysicalCard.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+
+        ctrl.replay();
+        decksActivity.removePhysicalCardFromDeck("Owned", new PhysicalCard(Game.MAGIC, 111, Status.Good, "This is a valid description"),
+                (Boolean bool) -> {
+                });
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testRemovePhysicalCardFromDeckForSuccess(Boolean input) {
+        mockRpcService.removePhysicalCardFromDeck(anyString(), anyString(), isA(PhysicalCard.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(input);
+            return null;
+        });
+
+        ctrl.replay();
+        decksActivity.removePhysicalCardFromDeck("Owned", new PhysicalCard(Game.MAGIC, 111, Status.Good, "This is a valid description"), Assertions::assertNotNull);
         ctrl.verify();
     }
 }

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -128,4 +128,60 @@ public class DecksActivityTest {
         decksActivity.removePhysicalCardFromDeck("Owned", new PhysicalCard(Game.MAGIC, 111, Status.Good, "This is a valid description"), Assertions::assertNotNull);
         ctrl.verify();
     }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testCreateCustomDeckForInvalidDeckName(String input) {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.createCustomDeck(input);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testCreateCustomDeckForValidDeckNameForFailure(Exception e) {
+        mockRpcService.addDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.createCustomDeck("custom_deck");
+        ctrl.verify();
+    }
+
+    @Test
+    public void testCreateCustomDeckForValidDeckNameForSuccessAndFalseReturn() {
+        mockRpcService.addDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(false);
+            return null;
+        });
+        mockDecksView.displayAlert("deck already exists");
+        ctrl.replay();
+        decksActivity.createCustomDeck("custom_deck");
+        ctrl.verify();
+    }
+
+    @Test
+    public void testCreateCustomDeckForValidDeckNameForSuccessAndTrueReturn() {
+        String deckName = "custom_deck";
+        mockRpcService.addDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(true);
+            return null;
+        });
+        mockDecksView.displayAddedCustomDeck(deckName);
+        ctrl.replay();
+        decksActivity.createCustomDeck(deckName);
+        ctrl.verify();
+    }
 }


### PR DESCRIPTION
This PR implements #148, #149 and adds a new method createCustomDeck in the DecksActivity to make an RPC call and add a custom deck. Once the custom deck is successfully created, it is added to the list of decks on the page.
Tests for the new method were also added.