### PR TITLE
[UC18#150] Created RPC to Remove a Custom Deck

### DIFF
--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -47,10 +47,22 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
 
     @Override
     public boolean addDeck(String token, String deckName) throws AuthException {
-        String email = AuthServiceImpl.checkTokenValidity(token,
-                db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
+        String email = AuthServiceImpl.checkTokenValidity(token, db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
         Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
         return addDeck(email, deckName, false, deckMap);
+    }
+
+    public boolean removeCustomDeck(String token, String deckName) throws AuthException {
+        String email = AuthServiceImpl.checkTokenValidity(token, db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
+        Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
+        Map<String, Deck> userDecks = deckMap.get(email);
+        Deck deck = userDecks.get(deckName);
+        if (deck == null || deck.isDefault()) {
+            return false;
+        }
+        userDecks.remove(deckName, deck);
+        deckMap.put(email, userDecks);
+        return true;
     }
 
     public static boolean createDefaultDecks(String email, Map<String, Map<String, Deck>> deckMap) {
@@ -159,17 +171,7 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
 
     @Override
     public List<PhysicalCardWithName> getMyDeck(String token, String deckName) throws AuthException {
-        return getUserDeck(
-                AuthServiceImpl.checkTokenValidity(
-                        token,
-                        db.getPersistentMap(getServletContext(),
-                                LOGIN_MAP_NAME,
-                                Serializer.STRING,
-                                new GsonSerializer<>(gson)
-                        )
-                ),
-                deckName
-        );
+        return getUserDeck(AuthServiceImpl.checkTokenValidity(token, db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson))), deckName);
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/shared/DeckService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckService.java
@@ -14,6 +14,8 @@ public interface DeckService extends RemoteService {
 
     boolean addDeck(String token, String deckName) throws AuthException;
 
+    boolean removeCustomDeck(String token, String deckName) throws AuthException;
+
     boolean addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description) throws BaseException;
 
     boolean removePhysicalCardFromDeck(String token, String deckName, PhysicalCard pCard) throws BaseException;

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -8,6 +8,8 @@ import java.util.List;
 public interface DeckServiceAsync {
     void addDeck(String email, String deckName, AsyncCallback<Boolean> callback);
 
+    void removeCustomDeck(String token, String deckName, AsyncCallback<Boolean> callback);
+
     void addPhysicalCardToDeck(String token, Game game, String deckName, int cardId, Status status, String description, AsyncCallback<Boolean> callback);
 
     void removePhysicalCardFromDeck(String token, String deckName, PhysicalCard pCard, AsyncCallback<Boolean> callback);


### PR DESCRIPTION
As the title says, this PR implements the feature requested in issue #150 where is highlited the necessity of removing a custom deck after creating it if no more necessary.
The code is also been tested with JUnit Tests for all possible occurrences like invalid token, invalid deck name or trying to remove a default deck (Owned, Wished)  