### PR TITLE
[UC18#152] Added functionality for users to delete their own custom decks

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
@@ -1,0 +1,7 @@
+package com.aadm.cardexchange.client.handlers;
+
+import java.util.function.Consumer;
+
+public interface ImperativeHandleDeckRemove {
+    void onClickRemoveCustomDeck(String deck, Consumer<Boolean> isRemoved);
+}

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -118,11 +118,29 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
                 }
             }
         });
-
     }
 
     @Override
-    public void deleteCustomDeck() {
+    public void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved) {
+        if (checkDeckNameInvalidity(deckName)) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
 
+        rpcService.removeCustomDeck(authSubject.getToken(), deckName, new AsyncCallback<Boolean>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                isRemoved.accept(result);
+            }
+        });
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -27,6 +27,6 @@ public interface DecksView extends IsWidget {
 
         void createCustomDeck(String deckName);
 
-        void deleteCustomDeck();
+        void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -1,18 +1,17 @@
 package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleDeckRemove;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -21,9 +20,9 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck {
+public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleDeckRemove {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
-    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your custom deck";
+    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your new custom deck";
     Presenter presenter;
     @UiField
     HTMLPanel decksContainer;
@@ -39,16 +38,6 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
         for (String deckName : data) {
             decksContainer.add(createDeck(deckName));
         }
-    }
-
-    @Override
-    public void onShowDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData) {
-        presenter.fetchUserDeck(deckName, setDeckData);
-    }
-
-    @Override
-    public void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
-        presenter.removePhysicalCardFromDeck(deckName, pCard, isRemoved);
     }
 
     @Override
@@ -72,13 +61,23 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
         if (deckName.equals("Owned") || deckName.equals("Wished")) {
             return new DeckWidget(this, null, null, deckName);
         } else {
-            Button removeButton = new Button("x", (ClickHandler) e -> {
-                if (Window.confirm("Are you sure you want to remove this deck?"))
-                    presenter.deleteCustomDeck();
-            });
-            removeButton.setStyleName("deckButton");
-            return new DeckWidget(this, removeButton, null, deckName);
+            return new DeckWidget(this, this, null, deckName);
         }
+    }
+
+    @Override
+    public void onShowDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData) {
+        presenter.fetchUserDeck(deckName, setDeckData);
+    }
+
+    @Override
+    public void onClickRemoveCustomDeck(String deckName, Consumer<Boolean> isRemoved) {
+        presenter.deleteCustomDeck(deckName, isRemoved);
+    }
+
+    @Override
+    public void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
+        presenter.removePhysicalCardFromDeck(deckName, pCard, isRemoved);
     }
 
     @UiHandler(value = "newDeckButton")

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -1,16 +1,15 @@
 package com.aadm.cardexchange.client.widgets;
 
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardRemove;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardSelection;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardsSelection;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
+import com.aadm.cardexchange.client.handlers.*;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.HeadingElement;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -36,7 +35,7 @@ public class DeckWidget extends Composite implements ImperativeHandleCardSelecti
     HTMLPanel actions;
 
     @UiConstructor
-    public DeckWidget(ImperativeHandleDeck deckHandler, Button removeButton, ImperativeHandleCardsSelection selectionHandler, String name) {
+    public DeckWidget(ImperativeHandleDeck deckHandler, ImperativeHandleDeckRemove removeHandler, ImperativeHandleCardsSelection selectionHandler, String name) {
         this.deckHandler = deckHandler;
         this.selectionHandler = selectionHandler;
         initWidget(uiBinder.createAndBindUi(this));
@@ -54,7 +53,20 @@ public class DeckWidget extends Composite implements ImperativeHandleCardSelecti
             });
         }
 
-        if (removeButton != null) actions.add(removeButton);
+        if (removeHandler != null) {
+            Button removeButton = new Button("x", (ClickHandler) e -> {
+                if (Window.confirm("Are you sure you want to remove this deck?"))
+                    removeHandler.onClickRemoveCustomDeck(deckName.getInnerText(), (Boolean isRemoved) -> {
+                        if (isRemoved) {
+                            removeFromParent();
+                        } else {
+                            Window.alert("Deck cannot be deleted. It may be a default deck or does not exist.");
+                        }
+                    });
+            });
+            removeButton.setStyleName("deckButton");
+            actions.add(removeButton);
+        }
     }
 
     public void setData(List<PhysicalCardWithName> data, String selectedCardId) {

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -17,10 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -182,6 +179,64 @@ public class DecksActivityTest {
         mockDecksView.displayAddedCustomDeck(deckName);
         ctrl.replay();
         decksActivity.createCustomDeck(deckName);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    public void testDeleteCustomDeckForInvalidDeckName(String input) {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.deleteCustomDeck(input, (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testDeleteCustomDeckForValidDeckNameForFailure(Exception e) {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testDeleteCustomDeckForValidDeckForSuccessAndFalseReturn() {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(false);
+            return null;
+        });
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", Assertions::assertFalse);
+        ctrl.verify();
+    }
+
+    @Test
+    public void testDeleteCustomDeckForValidDeckForSuccessAndTrueReturn() {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(true);
+            return null;
+        });
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", Assertions::assertTrue);
         ctrl.verify();
     }
 }


### PR DESCRIPTION
This PR implements #152 and adds a new method called deleteCustomDeck in the DecksActivity to remove a custom deck via RPC call. Once the custom deck is successfully deleted, it is removed from the list of decks on the page.
A function was passed to DeckWidget instead of a button to get reference to the DeckWidget.
Tests for the new method were also added.