### PR TITLE
[UC13#158#159] Implemented Edit Mode Button for users to allow modifying their owned/wished existing physical cards

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardsSelection.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCardsSelection.java
@@ -1,5 +1,0 @@
-package com.aadm.cardexchange.client.handlers;
-
-public interface ImperativeHandleCardsSelection {
-    void onChangeSelectedCards();
-}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
@@ -1,0 +1,7 @@
+package com.aadm.cardexchange.client.handlers;
+
+import java.util.function.Consumer;
+
+public interface ImperativeHandleDeckRemove {
+    void onClickRemoveCustomDeck(String deck, Consumer<Boolean> isRemoved);
+}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardEdit.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardEdit.java
@@ -1,0 +1,5 @@
+package com.aadm.cardexchange.client.handlers;
+
+public interface ImperativeHandlePhysicalCardEdit {
+    void onConfirmCardEdit();
+}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardRemove.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardRemove.java
@@ -4,7 +4,7 @@ import com.aadm.cardexchange.shared.models.PhysicalCard;
 
 import java.util.function.Consumer;
 
-public interface ImperativeHandleCardRemove {
+public interface ImperativeHandlePhysicalCardRemove {
     void onClickDeleteButton(PhysicalCard pCard, Consumer<Boolean> isRemoved);
 
 }

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardSelection.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardSelection.java
@@ -1,6 +1,6 @@
 package com.aadm.cardexchange.client.handlers;
 
-public interface ImperativeHandleCardSelection {
+public interface ImperativeHandlePhysicalCardSelection {
     void onChangeSelection();
 
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -118,11 +118,29 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
                 }
             }
         });
-
     }
 
     @Override
-    public void deleteCustomDeck() {
+    public void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved) {
+        if (checkDeckNameInvalidity(deckName)) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
 
+        rpcService.removeCustomDeck(authSubject.getToken(), deckName, new AsyncCallback<Boolean>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                isRemoved.accept(result);
+            }
+        });
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -27,6 +27,6 @@ public interface DecksView extends IsWidget {
 
         void createCustomDeck(String deckName);
 
-        void deleteCustomDeck();
+        void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -2,6 +2,7 @@ package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
 import com.aadm.cardexchange.client.handlers.ImperativeHandleDeckRemove;
+import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardEdit;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
@@ -20,7 +21,8 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleDeckRemove {
+public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleDeckRemove,
+        ImperativeHandlePhysicalCardEdit {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
     private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your new custom deck";
     Presenter presenter;
@@ -59,9 +61,9 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     // factory
     private DeckWidget createDeck(String deckName) {
         if (deckName.equals("Owned") || deckName.equals("Wished")) {
-            return new DeckWidget(this, null, null, deckName);
+            return new DeckWidget(this, null, null, this, deckName);
         } else {
-            return new DeckWidget(this, this, null, deckName);
+            return new DeckWidget(this, this, null, null, deckName);
         }
     }
 
@@ -88,6 +90,11 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     @Override
     public void setPresenter(DecksView.Presenter presenter) {
         this.presenter = presenter;
+    }
+
+    @Override
+    public void onConfirmCardEdit() {
+        Window.alert("MODIFICATA!");
     }
 
     interface DecksViewImplUIBinder extends UiBinder<Widget, DecksViewImpl> {

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -1,18 +1,17 @@
 package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
+import com.aadm.cardexchange.client.handlers.ImperativeHandleDeckRemove;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -21,9 +20,9 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck {
+public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleDeckRemove {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
-    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your custom deck";
+    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your new custom deck";
     Presenter presenter;
     @UiField
     HTMLPanel decksContainer;
@@ -39,16 +38,6 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
         for (String deckName : data) {
             decksContainer.add(createDeck(deckName));
         }
-    }
-
-    @Override
-    public void onShowDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData) {
-        presenter.fetchUserDeck(deckName, setDeckData);
-    }
-
-    @Override
-    public void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
-        presenter.removePhysicalCardFromDeck(deckName, pCard, isRemoved);
     }
 
     @Override
@@ -72,13 +61,23 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
         if (deckName.equals("Owned") || deckName.equals("Wished")) {
             return new DeckWidget(this, null, null, deckName);
         } else {
-            Button removeButton = new Button("x", (ClickHandler) e -> {
-                if (Window.confirm("Are you sure you want to remove this deck?"))
-                    presenter.deleteCustomDeck();
-            });
-            removeButton.setStyleName("deckButton");
-            return new DeckWidget(this, removeButton, null, deckName);
+            return new DeckWidget(this, this, null, deckName);
         }
+    }
+
+    @Override
+    public void onShowDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData) {
+        presenter.fetchUserDeck(deckName, setDeckData);
+    }
+
+    @Override
+    public void onClickRemoveCustomDeck(String deckName, Consumer<Boolean> isRemoved) {
+        presenter.deleteCustomDeck(deckName, isRemoved);
+    }
+
+    @Override
+    public void onRemovePhysicalCard(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved) {
+        presenter.removePhysicalCardFromDeck(deckName, pCard, isRemoved);
     }
 
     @UiHandler(value = "newDeckButton")

--- a/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
@@ -1,6 +1,6 @@
 package com.aadm.cardexchange.client.views;
 
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardsSelection;
+import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardSelection;
 import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
@@ -14,7 +14,7 @@ import com.google.gwt.user.client.ui.Widget;
 import java.util.List;
 
 
-public class NewExchangeViewImpl extends Composite implements NewExchangeView, ImperativeHandleCardsSelection {
+public class NewExchangeViewImpl extends Composite implements NewExchangeView, ImperativeHandlePhysicalCardSelection {
     private static final NewExchangeViewImpl.NewExchangeViewImplUIBinder uiBinder = GWT.create(NewExchangeViewImpl.NewExchangeViewImplUIBinder.class);
     Presenter presenter;
     @UiField(provided = true)
@@ -27,8 +27,8 @@ public class NewExchangeViewImpl extends Composite implements NewExchangeView, I
     Button acceptButton;
 
     public NewExchangeViewImpl() {
-        this.senderDeck = new DeckWidget(null, null, this, "Your Owned Cards");
-        this.receiverDeck = new DeckWidget(null, null, this, "");
+        this.senderDeck = new DeckWidget(null, null, this, null, "Your Owned Cards");
+        this.receiverDeck = new DeckWidget(null, null, this, null, "");
         initWidget(uiBinder.createAndBindUi(this));
         cancelButton.addClickHandler(e -> Window.alert("Abort Exchange"));
         acceptButton.addClickHandler(e -> presenter.createProposal(senderDeck.getDeckSelectedCards(), receiverDeck.getDeckSelectedCards()));
@@ -57,7 +57,7 @@ public class NewExchangeViewImpl extends Composite implements NewExchangeView, I
     }
 
     @Override
-    public void onChangeSelectedCards() {
+    public void onChangeSelection() {
         acceptButton.setEnabled(!receiverDeck.getDeckSelectedCards().isEmpty() && !senderDeck.getDeckSelectedCards().isEmpty());
     }
 

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.java
@@ -4,11 +4,14 @@ import com.aadm.cardexchange.client.handlers.ImperativeHandleAddCardToDeckModal;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.*;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.TextArea;
+import com.google.gwt.user.client.ui.Widget;
 
 public class AddCardToDeckModalWidget extends DialogBox {
     @UiField
-    ListBox status;
+    StatusWidget status;
     @UiField
     TextArea description;
     @UiField
@@ -25,12 +28,12 @@ public class AddCardToDeckModalWidget extends DialogBox {
         setGlassEnabled(true);
         setStyleName("my-Modal");
         noButton.addClickHandler(clickEvent -> hide());
-        yesButton.addClickHandler(clickEvent -> parent.onClickModalYes(status.getSelectedValue(), description.getValue()));
+        yesButton.addClickHandler(clickEvent -> parent.onClickModalYes(status.getSelection(), description.getValue()));
     }
 
     @Override
     public void hide() {
-        status.setItemSelected(0, true);
+        status.clearSelection();
         description.setText("");
         super.hide();
     }

--- a/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/AddCardToDeckModalWidget.ui.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:m='urn:import:com.aadm.cardexchange.client.widgets'>
     <ui:style>
         @external .my-Modal .Caption;
         .my-Modal .Caption {
@@ -45,10 +46,6 @@
             color: #222;
         }
 
-        .status {
-            font-size: 1.1em;
-        }
-
         .descriptionArea {
             width: 10rem;
             height: 5rem;
@@ -81,14 +78,8 @@
     </ui:style>
     <g:HTMLPanel styleName="{style.content}">
         <div class="{style.field}">
-            <div class="{style.label}">State</div>
-            <g:ListBox styleName="{style.status}" ui:field='status'>
-                <g:item value="1">1 - VeryDamaged</g:item>
-                <g:item value="2">2 - Damaged</g:item>
-                <g:item value="3">3 - Fair</g:item>
-                <g:item value="4">4 - Good</g:item>
-                <g:item value="5">5 - Excellent</g:item>
-            </g:ListBox>
+            <div class="{style.label}">Status</div>
+            <m:StatusWidget ui:field="status"/>
         </div>
         <div class="{style.field}">
             <div class="{style.label}">Description</div>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -1,16 +1,15 @@
 package com.aadm.cardexchange.client.widgets;
 
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardRemove;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardSelection;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleCardsSelection;
-import com.aadm.cardexchange.client.handlers.ImperativeHandleDeck;
+import com.aadm.cardexchange.client.handlers.*;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.HeadingElement;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -36,7 +35,7 @@ public class DeckWidget extends Composite implements ImperativeHandleCardSelecti
     HTMLPanel actions;
 
     @UiConstructor
-    public DeckWidget(ImperativeHandleDeck deckHandler, Button removeButton, ImperativeHandleCardsSelection selectionHandler, String name) {
+    public DeckWidget(ImperativeHandleDeck deckHandler, ImperativeHandleDeckRemove removeHandler, ImperativeHandleCardsSelection selectionHandler, String name) {
         this.deckHandler = deckHandler;
         this.selectionHandler = selectionHandler;
         initWidget(uiBinder.createAndBindUi(this));
@@ -54,7 +53,20 @@ public class DeckWidget extends Composite implements ImperativeHandleCardSelecti
             });
         }
 
-        if (removeButton != null) actions.add(removeButton);
+        if (removeHandler != null) {
+            Button removeButton = new Button("x", (ClickHandler) e -> {
+                if (Window.confirm("Are you sure you want to remove this deck?"))
+                    removeHandler.onClickRemoveCustomDeck(deckName.getInnerText(), (Boolean isRemoved) -> {
+                        if (isRemoved) {
+                            removeFromParent();
+                        } else {
+                            Window.alert("Deck cannot be deleted. It may be a default deck or does not exist.");
+                        }
+                    });
+            });
+            removeButton.setStyleName("deckButton");
+            actions.add(removeButton);
+        }
     }
 
     public void setData(List<PhysicalCardWithName> data, String selectedCardId) {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.ui.xml
@@ -6,10 +6,6 @@
             box-shadow: 0 0 0 4px gold inset !important;
         }
 
-        .cardDiscarded {
-            border: none;
-        }
-
         .card {
             position: relative;
             display: flex;
@@ -27,38 +23,65 @@
         }
 
         .cardStatus {
-            color: rgb(68, 68, 68);
+            color: #444;
             padding: 1rem 0;
-            font-size: 0.9em;
+            font-size: .9em;
             font-weight: bold;
             text-transform: uppercase;
         }
 
         .cardDescription {
             word-break: break-word;
+            padding: 0.55rem 0.55rem;
         }
 
-        .deleteButton {
+        .cardDescription[contenteditable="true"] {
+            outline: none;
+            border: 2px dashed #3A3FF0;
+            border-radius: 6px;
+            background: #e9efff;
+        }
+
+        .cardActions {
             position: absolute;
             top: 5px;
             right: 5px;
+            display: flex;
+            gap: 4px;
+        }
+
+        .cardActions > button {
+            font-size: 1.1em;
             width: 1.5rem;
             height: 1.5rem;
-            color: red;
             background: #fff;
-            border: solid 1px red;
             border-radius: 50%;
             text-align: center;
         }
 
+        .editButton {
+            border: 1px solid #3A3FF0;
+            color: #3A3FF0;
+            transform: scaleX(-1);
+        }
+
+        .editButton:hover, .toggle {
+            background: #e9efff !important;
+        }
+
+        .deleteButton {
+            color: #f03a3a;
+            border: 1px solid #f03a3a;
+        }
+
         .deleteButton:hover {
-            color: white;
-            background: red;
+            background: #ffe9e9;
         }
     </ui:style>
     <g:HTMLPanel styleName="{style.card}" ui:field="cardContainer">
         <h2 ui:field="cardName"/>
         <div ui:field="cardDescription" class="{style.cardDescription}"/>
-        <div ui:field="cardStatus" class="{style.cardStatus}"/>
+        <g:HTMLPanel ui:field="cardStatus" styleName="{style.cardStatus}"/>
+        <g:HTMLPanel ui:field="cardActions" styleName="{style.cardActions}"/>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/StatusWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/StatusWidget.java
@@ -1,0 +1,29 @@
+package com.aadm.cardexchange.client.widgets;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class StatusWidget extends Composite {
+    private static final StatusWidgetUiBinder uiBinder = GWT.create(StatusWidgetUiBinder.class);
+    @UiField
+    ListBox status;
+
+    public StatusWidget() {
+        initWidget(uiBinder.createAndBindUi(this));
+    }
+
+    public String getSelection() {
+        return status.getSelectedValue();
+    }
+
+    public void clearSelection() {
+        status.setItemSelected(0, true);
+    }
+
+    interface StatusWidgetUiBinder extends UiBinder<Widget, StatusWidget> {
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/StatusWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/StatusWidget.ui.xml
@@ -1,0 +1,15 @@
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+    <ui:style>
+        .status {
+            font-size: 1.1em;
+        }
+    </ui:style>
+    <g:ListBox styleName="{style.status}" ui:field='status'>
+        <g:item value="1">1 - VeryDamaged</g:item>
+        <g:item value="2">2 - Damaged</g:item>
+        <g:item value="3">3 - Fair</g:item>
+        <g:item value="4">4 - Good</g:item>
+        <g:item value="5">5 - Excellent</g:item>
+    </g:ListBox>
+</ui:UiBinder>

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -17,10 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -182,6 +179,64 @@ public class DecksActivityTest {
         mockDecksView.displayAddedCustomDeck(deckName);
         ctrl.replay();
         decksActivity.createCustomDeck(deckName);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    public void testDeleteCustomDeckForInvalidDeckName(String input) {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.deleteCustomDeck(input, (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testDeleteCustomDeckForValidDeckNameForFailure(Exception e) {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", (Boolean bool) -> {
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testDeleteCustomDeckForValidDeckForSuccessAndFalseReturn() {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(false);
+            return null;
+        });
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", Assertions::assertFalse);
+        ctrl.verify();
+    }
+
+    @Test
+    public void testDeleteCustomDeckForValidDeckForSuccessAndTrueReturn() {
+        mockRpcService.removeCustomDeck(anyString(), anyString(), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<Boolean> callback = (AsyncCallback<Boolean>) args[args.length - 1];
+            callback.onSuccess(true);
+            return null;
+        });
+
+        ctrl.replay();
+        decksActivity.deleteCustomDeck("Test", Assertions::assertTrue);
         ctrl.verify();
     }
 }


### PR DESCRIPTION
This PR implements #158 and #159. Adding an Edit Button for modification of existing Physical Deck Cards. The button puts the physical cards in the Decks View into an editable state, allowing users to modify the description and status fields. This button is only visible on owned-wished default decks."