### PR TITLE
[UC15#154] Implemented 'Add' button in the deck header of custom decks to enable users to add their own physical cards to a custom deck

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCustomDeck.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCustomDeck.java
@@ -1,0 +1,12 @@
+package com.aadm.cardexchange.client.handlers;
+
+import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface ImperativeHandleCustomDeck {
+    void onClickRemoveCustomDeck(String deck, Consumer<Boolean> isRemoved);
+
+    void onClickAddPhysicalCardsToCustomDeck(Consumer<List<PhysicalCardWithName>> getSelectedPhysicalCards);
+}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleDeckRemove.java
@@ -1,7 +1,0 @@
-package com.aadm.cardexchange.client.handlers;
-
-import java.util.function.Consumer;
-
-public interface ImperativeHandleDeckRemove {
-    void onClickRemoveCustomDeck(String deck, Consumer<Boolean> isRemoved);
-}

--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardSelection.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardSelection.java
@@ -2,5 +2,4 @@ package com.aadm.cardexchange.client.handlers;
 
 public interface ImperativeHandlePhysicalCardSelection {
     void onChangeSelection();
-
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -59,6 +59,11 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
         });
     }
 
+    @Override
+    public void updatePhysicalCard() {
+
+    }
+
     private boolean checkDeckNameInvalidity(String deckName) {
         return deckName == null || deckName.isEmpty();
     }
@@ -142,5 +147,10 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
                 isRemoved.accept(result);
             }
         });
+    }
+
+    @Override
+    public void addPhysicalCardsToCustomDeck(List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck) {
+
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -23,10 +23,14 @@ public interface DecksView extends IsWidget {
     interface Presenter {
         void fetchUserDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData);
 
+        void updatePhysicalCard();
+
         void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved);
 
         void createCustomDeck(String deckName);
 
         void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved);
+
+        void addPhysicalCardsToCustomDeck(List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -27,6 +27,7 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     HTMLPanel cards;
     @UiField
     Button showButton;
+    Button addButton;
     boolean isVisible;
     List<PhysicalCard> deckSelectedCards;
     ImperativeHandleDeck deckHandler;
@@ -36,7 +37,7 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     HTMLPanel actions;
 
     @UiConstructor
-    public DeckWidget(ImperativeHandleDeck deckHandler, ImperativeHandleDeckRemove customDeckHandler, ImperativeHandlePhysicalCardSelection cardSelectionHandler,
+    public DeckWidget(ImperativeHandleDeck deckHandler, ImperativeHandleCustomDeck customDeckHandler, ImperativeHandlePhysicalCardSelection cardSelectionHandler,
                       ImperativeHandlePhysicalCardEdit cardEditHandler, String name) {
         this.deckHandler = deckHandler;
         this.cardSelectionHandler = cardSelectionHandler;
@@ -57,6 +58,9 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
         }
 
         if (customDeckHandler != null) {
+            addButton = new Button("&#43;", (ClickHandler) e -> {
+                customDeckHandler.onClickAddPhysicalCardsToCustomDeck(pCards -> setData(pCards, null));
+            });
             Button removeButton = new Button("x", (ClickHandler) e -> {
                 if (Window.confirm("Are you sure you want to remove this deck?"))
                     customDeckHandler.onClickRemoveCustomDeck(deckName.getInnerText(), (Boolean isRemoved) -> {
@@ -67,7 +71,10 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
                         }
                     });
             });
+            addButton.setStyleName("deckButton");
+            addButton.setEnabled(false);
             removeButton.setStyleName("deckButton");
+            actions.add(addButton);
             actions.add(removeButton);
         }
     }
@@ -86,11 +93,21 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
 
     // factory
     private PhysicalCardWidget createPhysicalCardWidget(PhysicalCardWithName pCard) {
-        return new PhysicalCardWidget(pCard, this, deckHandler != null ? this : null, cardEditHandler != null ? this : null);
+        return new PhysicalCardWidget(pCard,
+                cardSelectionHandler != null ? this : null,
+                deckHandler != null ? this : null,
+                cardEditHandler != null ? this : null
+        );
     }
 
     public void setDeckName(String name) {
         deckName.setInnerText(name);
+    }
+
+    public void setAddButtonEnabled(boolean isEnabled) {
+        if (addButton != null) {
+            addButton.setEnabled(isEnabled);
+        }
     }
 
     public List<PhysicalCard> getDeckSelectedCards() {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.ui.xml
@@ -34,7 +34,7 @@
             width: 100%;
             justify-content: flex-start;
             align-items: stretch;
-            overflow-x: scroll;
+            overflow-x: auto;
             background: #eee;
         }
     </ui:style>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
@@ -3,7 +3,6 @@ package com.aadm.cardexchange.client.widgets;
 import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardEdit;
 import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardRemove;
 import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardSelection;
-import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
@@ -43,10 +42,12 @@ public class PhysicalCardWidget extends Composite {
                 "cards/" + pCard.getGameType() + "/" + pCard.getCardId()));
 
         // card selection
-        cardContainer.addDomHandler(e -> {
-            setSelected();
-            selectionHandler.onChangeSelection();
-        }, ClickEvent.getType());
+        if (selectionHandler != null) {
+            cardContainer.addDomHandler(e -> {
+                setSelected();
+                selectionHandler.onChangeSelection();
+            }, ClickEvent.getType());
+        }
 
         // card edit
         if (editHandler != null) {
@@ -79,7 +80,7 @@ public class PhysicalCardWidget extends Composite {
         setPhysicalCard();
     }
 
-    public PhysicalCard getPhysicalCard() {
+    public PhysicalCardWithName getPhysicalCard() {
         return pCard;
     }
 

--- a/src/main/webapp/CardExchange.css
+++ b/src/main/webapp/CardExchange.css
@@ -34,3 +34,8 @@ html, body {
     background-color: #eee;
     color: #444;
 }
+
+.deckButton:disabled {
+    background: gainsboro;
+    color: #444;
+}


### PR DESCRIPTION
This PR implements #154 and adds an 'add' button to handle the addition of physical cards to custom decks. This button is disabled if no physical cards are selected. Function drilling was done from the DecksView to the DeckWidget.
