### PR TITLE
[UC15#153] Implemented RPC addPhysicalCardsToCustomDeck that allows multiple physical card additions to custom decks

### DIFF
--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -188,6 +188,12 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         return getPhysicalCardByCardIdAndDeckName(cardId, OWNED_DECK);
     }
 
+    @Override
+    public List<PhysicalCardWithEmail> getWishedPhysicalCardsByCardId(int cardId) throws InputException {
+        CardServiceImpl.checkCardIdInvalidity(cardId);
+        return getPhysicalCardByCardIdAndDeckName(cardId, WISHED_DECK);
+    }
+
     private List<PhysicalCardWithName> joinPhysicalCardsWithCatalogCards(Set<PhysicalCard> pCards) {
         List<PhysicalCardWithName> pCardsWithName = new LinkedList<>();
         for (PhysicalCard pCard : pCards) {
@@ -223,11 +229,5 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         deckMap.put(customDeckName, userDecks);
         // Return the modified deck's card list
         return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
-    }
-
-    @Override
-    public List<PhysicalCardWithEmail> getWishedPhysicalCardsByCardId(int cardId) throws InputException {
-        CardServiceImpl.checkCardIdInvalidity(cardId);
-        return getPhysicalCardByCardIdAndDeckName(cardId, WISHED_DECK);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -6,6 +6,7 @@ import com.aadm.cardexchange.server.mapdb.MapDBConstants;
 import com.aadm.cardexchange.server.mapdb.MapDBImpl;
 import com.aadm.cardexchange.shared.DeckService;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.common.reflect.TypeToken;
@@ -24,7 +25,8 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
     private static final String WISHED_DECK = "Wished";
     private final MapDB db;
     private final Gson gson = new Gson();
-    private final Type type = new TypeToken<Map<String, Deck>>() {}.getType();
+    private final Type type = new TypeToken<Map<String, Deck>>() {
+    }.getType();
 
     public DeckServiceImpl() {
         db = new MapDBImpl();
@@ -151,22 +153,9 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
 
     private List<PhysicalCardWithName> getUserDeck(String userEmail, String deckName) {
         Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
-        Map<String, Deck> allUserDecks = deckMap.get(userEmail);
-        Deck userDeck = allUserDecks.get(deckName);
-        List<PhysicalCardWithName> pCardsWithName = new ArrayList<>();
-        for (PhysicalCard pCard : userDeck.getPhysicalCards()) {
-            String cardName = CardServiceImpl.getNameCard(
-                    pCard.getCardId(),
-                    db.getCachedMap(
-                            getServletContext(),
-                            CardServiceImpl.getCardMap(pCard.getGameType()),
-                            Serializer.INTEGER,
-                            new GsonSerializer<>(gson)
-                    )
-            );
-            pCardsWithName.add(new PhysicalCardWithName(pCard, cardName));
-        }
-        return pCardsWithName;
+        Map<String, Deck> userDecks = deckMap.get(userEmail);
+        Deck userDeck = userDecks.get(deckName);
+        return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
     }
 
     @Override
@@ -203,5 +192,42 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
             throw new InputException("Invalid cardId");
         }
         return getPhysicalCardByCardIdAndDeckName(cardId, OWNED_DECK);
+    }
+
+    private List<PhysicalCardWithName> joinPhysicalCardsWithCatalogCards(Set<PhysicalCard> pCards) {
+        List<PhysicalCardWithName> pCardsWithName = new LinkedList<>();
+        for (PhysicalCard pCard : pCards) {
+            pCardsWithName.add(new PhysicalCardWithName(
+                    pCard,
+                    CardServiceImpl.getNameCard(pCard.getCardId(), db.getCachedMap(
+                            getServletContext(),
+                            CardServiceImpl.getCardMap(pCard.getGameType()),
+                            Serializer.INTEGER,
+                            new GsonSerializer<>(gson)
+                    ))
+            ));
+        }
+        return pCardsWithName;
+    }
+
+    @Override
+    public List<PhysicalCardWithName> addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards) throws AuthException, InputException, DeckNotFoundException {
+        String userEmail = AuthServiceImpl.checkTokenValidity(token,
+                db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
+        if (customDeckName == null || customDeckName.isEmpty())
+            throw new InputException("Invalid deck name");
+        if (customDeckName.equals(OWNED_DECK) || customDeckName.equals(WISHED_DECK))
+            throw new InputException("Default deck names not allowed for custom deck");
+        if (pCards.isEmpty())
+            throw new InputException("Empty list of physical cards");
+        Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
+        Map<String, Deck> userDecks = deckMap.get(userEmail);
+        Deck userDeck = userDecks.get(customDeckName);
+        if (userDeck == null)
+            throw new DeckNotFoundException("Custom deck '" + customDeckName + "' not found.");
+        pCards.forEach(userDeck::addPhysicalCard);
+        deckMap.put(customDeckName, userDecks);
+        // Return the modified deck's card list
+        return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
     }
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckService.java
@@ -27,4 +27,6 @@ public interface DeckService extends RemoteService {
     List<PhysicalCardWithName> getUserOwnedDeck(String email) throws AuthException;
 
     List<PhysicalCardWithEmail> getOwnedPhysicalCardsByCardId(int cardId) throws InputException;
+
+    List<PhysicalCardWithName> addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards) throws BaseException;
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -21,4 +21,6 @@ public interface DeckServiceAsync {
     void getUserOwnedDeck(String email, AsyncCallback<List<PhysicalCardWithName>> callback);
 
     void getOwnedPhysicalCardsByCardId(int cardId, AsyncCallback<List<PhysicalCardWithEmail>> callback);
+
+    void addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards, AsyncCallback<List<PhysicalCardWithName>> callback);
 }

--- a/src/main/java/com/aadm/cardexchange/shared/exceptions/DeckNotFoundException.java
+++ b/src/main/java/com/aadm/cardexchange/shared/exceptions/DeckNotFoundException.java
@@ -1,0 +1,13 @@
+package com.aadm.cardexchange.shared.exceptions;
+
+
+public class DeckNotFoundException extends BaseException {
+    private static final long serialVersionUID = -9069721007995377785L;
+
+    public DeckNotFoundException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public DeckNotFoundException() {
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/shared/models/Status.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/Status.java
@@ -25,11 +25,13 @@ public enum Status {
                                         value == 5 ? Excellent :
                                                 null;
     }
+
     private static final List<Status> VALUES =
             Collections.unmodifiableList(Arrays.asList(values()));
     private static final int SIZE = VALUES.size();
     private static final Random RANDOM = new Random();
-    public static Status randomGame()  {
+
+    public static Status randomStatus() {
         return VALUES.get(RANDOM.nextInt(SIZE));
     }
 

--- a/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
@@ -370,10 +370,10 @@ public class DeckServiceTest {
     }
 
     private void setupDefaultDecks(String deckName, String mail1, String mail2) {
-        PhysicalCard mockPCard1 = new PhysicalCard(Game.randomGame(), 1111, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard2 = new PhysicalCard(Game.randomGame(), 1111, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard3 = new PhysicalCard(Game.randomGame(), 2222, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard4 = new PhysicalCard(Game.randomGame(), 3333, Status.randomGame(), "This is the card that I want.");
+        PhysicalCard mockPCard1 = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard2 = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard3 = new PhysicalCard(Game.randomGame(), 2222, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard4 = new PhysicalCard(Game.randomGame(), 3333, Status.randomStatus(), "This is the card that I want.");
         Deck mockDeck1 = new Deck(deckName, true);
         Deck mockDeck2 = new Deck(deckName, true);
 
@@ -444,7 +444,7 @@ public class DeckServiceTest {
         // init Mocks
         String emailTest1 = "test1@test.it";
         String emailTest2 = "test2@test.it";
-        setupDefaultDecks("Owned",  emailTest1,  emailTest2);
+        setupDefaultDecks("Owned", emailTest1, emailTest2);
         ctrl.replay();
         List<PhysicalCardWithEmail> pCardsWithEmail = deckService.getOwnedPhysicalCardsByCardId(1111);
         ctrl.verify();
@@ -558,7 +558,7 @@ public class DeckServiceTest {
         // init mocks
         String emailTest1 = "test1@test.it";
         String emailTest2 = "test2@test.it";
-        setupDefaultDecks("Wished",  emailTest1,  emailTest2);
+        setupDefaultDecks("Wished", emailTest1, emailTest2);
 
         ctrl.replay();
         List<PhysicalCardWithEmail> pCardsWithEmail = deckService.getWishedPhysicalCardsByCardId(1111);

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -61,7 +61,7 @@ public class ExchangeServiceTest {
     private List<PhysicalCard> generateValidListPcard(int n) {
         List<PhysicalCard> myList = new ArrayList<>();
         for (int i = 0; i < n; i++) {
-            PhysicalCard mockPCard = new PhysicalCard(Game.randomGame(), (i + 3000), Status.randomGame(), "This is a valid description.");
+            PhysicalCard mockPCard = new PhysicalCard(Game.randomGame(), (i + 3000), Status.randomStatus(), "This is a valid description.");
             myList.add(mockPCard);
         }
         return myList;
@@ -103,7 +103,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForEmptySenderPCards() throws AuthException {
+    public void testAddProposalForEmptySenderPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -112,7 +112,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForNullSenderPCards() throws AuthException {
+    public void testAddProposalForNullSenderPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -121,7 +121,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForEmptyReceiverPCards() throws AuthException {
+    public void testAddProposalForEmptyReceiverPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -130,7 +130,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForNullReceiverPCards() throws AuthException {
+    public void testAddProposalForNullReceiverPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();


### PR DESCRIPTION
This PR implements #153, adding the necessary RPC for users to add multiple owned physical cards to one of theirs custom decks. To prevent code duplication, a method to join physical cards with catalog cards has been extracted. 
Exception handling has also been improved with the addition of a checked exception, `DeckNotFoundException`, for better client-side error management. 
Supplied with coverage for unit testing.