### PR TITLE
[UC19#134] Implemented Exchanges Page to allow users to view an interface containing their own exchange proposals, both sent and received

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleProposalList.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleProposalList.java
@@ -1,0 +1,5 @@
+package com.aadm.cardexchange.client.handlers;
+
+public interface ImperativeHandleProposalList {
+    void onClickProposalRow(int selectedProposalId);
+}

--- a/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
@@ -1,12 +1,21 @@
 package com.aadm.cardexchange.client.presenters;
 
 import com.aadm.cardexchange.client.views.ExchangesView;
+import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class ExchangesActivity extends AbstractActivity implements ExchangesView.Presenter {
     private final ExchangesView view;
+    List<Proposal> proposals = Arrays.asList(
+            new Proposal("alessiacrimaldi@gmail.com", "alessioarcara@gmail.com", Collections.emptyList(), Collections.emptyList()),
+            new Proposal("matteosacco@gmail.com", "davidefermi@gmail.com", Collections.emptyList(), Collections.emptyList())
+    );
 
     public ExchangesActivity(ExchangesView view) {
         this.view = view;
@@ -16,5 +25,7 @@ public class ExchangesActivity extends AbstractActivity implements ExchangesView
     public void start(AcceptsOneWidget acceptsOneWidget, EventBus eventBus) {
         view.setPresenter(this);
         acceptsOneWidget.setWidget(view.asWidget());
+        view.setFromYouProposalList(proposals);
+        view.setToYouProposalList(proposals);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
@@ -28,4 +28,9 @@ public class ExchangesActivity extends AbstractActivity implements ExchangesView
         view.setFromYouProposalList(proposals);
         view.setToYouProposalList(proposals);
     }
+
+    @Override
+    public void onStop() {
+        view.resetProposalLists();
+    }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.ui.xml
@@ -52,7 +52,7 @@
             align-self: center;
         }
 
-        .usersLists {
+        .userListsContainer {
             display: flex;
             justify-content: space-around;
         }
@@ -87,6 +87,6 @@
             </div>
         </div>
         <g:HTMLPanel styleName="{style.addCardToDeckContainer}" ui:field="addCardToDeckContainer"/>
-        <g:HTMLPanel styleName="{style.usersLists}" ui:field="userLists"/>
+        <g:HTMLPanel styleName="{style.userListsContainer}" ui:field="userLists"/>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
@@ -10,6 +10,8 @@ public interface ExchangesView extends IsWidget {
 
     void setToYouProposalList(List<Proposal> proposals);
 
+    void resetProposalLists();
+
     void setPresenter(Presenter presenter);
 
     interface Presenter {

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
@@ -1,8 +1,14 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.user.client.ui.IsWidget;
 
+import java.util.List;
+
 public interface ExchangesView extends IsWidget {
+    void setFromYouProposalList(List<Proposal> proposals);
+
+    void setToYouProposalList(List<Proposal> proposals);
 
     void setPresenter(Presenter presenter);
 

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
@@ -47,6 +47,12 @@ public class ExchangesViewImpl extends Composite implements ExchangesView, Imper
     }
 
     @Override
+    public void resetProposalLists() {
+        fromYouProposalList.resetTable();
+        toYouProposalList.resetTable();
+    }
+
+    @Override
     public void setPresenter(Presenter presenter) {
         this.presenter = presenter;
     }

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
@@ -1,26 +1,54 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleProposalList;
 import com.aadm.cardexchange.client.widgets.ProposalListWidget;
+import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 
-public class ExchangesViewImpl extends Composite implements ExchangesView {
+import java.util.List;
+
+public class ExchangesViewImpl extends Composite implements ExchangesView, ImperativeHandleProposalList {
     private static final ExchangesViewImplUIBinder uiBinder = GWT.create(ExchangesViewImplUIBinder.class);
-    @UiField
-    HTMLPanel proposalLists;
+    Presenter presenter;
+    @UiField (provided = true)
+    ProposalListWidget fromYouProposalList;
+    @UiField (provided = true)
+    ProposalListWidget toYouProposalList;
 
     public ExchangesViewImpl() {
+        fromYouProposalList = new ProposalListWidget("From you", "Receiver");
+        toYouProposalList = new ProposalListWidget("To you", "Sender");
         initWidget(uiBinder.createAndBindUi(this));
-        proposalLists.add(new ProposalListWidget("From you", "Receiver"));
-        proposalLists.add(new ProposalListWidget("To you", "Sender"));
+    }
+
+    @Override
+    public void setFromYouProposalList(List<Proposal> proposals) {
+        proposals.forEach(proposal ->
+                fromYouProposalList.addRow(proposal.getId(), "08-02-2023", proposal.getReceiverUserEmail(), this)
+        );
+    }
+
+    @Override
+    public void setToYouProposalList(List<Proposal> proposals) {
+        proposals.forEach(proposal ->
+                toYouProposalList.addRow(proposal.getId(), "08-02-2023", proposal.getSenderUserEmail(), this)
+        );
+    }
+
+    @Override
+    public void onClickProposalRow(int selectedProposalId) {
+        // There will be the code for opening the Proposal Page
+        Window.alert("This is the " + selectedProposalId + " proposal");
     }
 
     @Override
     public void setPresenter(Presenter presenter) {
+        this.presenter = presenter;
     }
 
     interface ExchangesViewImplUIBinder extends UiBinder<Widget, ExchangesViewImpl> {

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
@@ -1,15 +1,22 @@
 package com.aadm.cardexchange.client.views;
 
+import com.aadm.cardexchange.client.widgets.ProposalListWidget;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 public class ExchangesViewImpl extends Composite implements ExchangesView {
     private static final ExchangesViewImplUIBinder uiBinder = GWT.create(ExchangesViewImplUIBinder.class);
+    @UiField
+    HTMLPanel proposalLists;
 
     public ExchangesViewImpl() {
         initWidget(uiBinder.createAndBindUi(this));
+        proposalLists.add(new ProposalListWidget("From you", "Receiver"));
+        proposalLists.add(new ProposalListWidget("To you", "Sender"));
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
@@ -1,11 +1,24 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-             xmlns:g="urn:import:com.google.gwt.user.client.ui"
-             xmlns:m="urn:import:com.aadm.cardexchange.client.widgets">
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
     <ui:style>
+        .deckLayout {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            height: 100%;
+            text-align: center;
+            gap: 1rem;
+        }
 
+        .proposalsLists {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-evenly;
+        }
     </ui:style>
-    <g:HTMLPanel>
-
+    <g:HTMLPanel styleName="{style.deckLayout}">
+        <h1>User exchange proposals</h1>
+        <g:HTMLPanel styleName="{style.proposalsLists}" ui:field="proposalLists"/>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-             xmlns:g="urn:import:com.google.gwt.user.client.ui">
+             xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:m="urn:import:com.aadm.cardexchange.client.widgets">
     <ui:style>
         .deckLayout {
             display: flex;
@@ -19,6 +20,9 @@
     </ui:style>
     <g:HTMLPanel styleName="{style.deckLayout}">
         <h1>User exchange proposals</h1>
-        <g:HTMLPanel styleName="{style.proposalsLists}" ui:field="proposalLists"/>
+        <div class="{style.proposalsLists}">
+            <m:ProposalListWidget ui:field="fromYouProposalList"/>
+            <m:ProposalListWidget ui:field="toYouProposalList"/>
+        </div>
     </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.ui.xml
@@ -12,7 +12,7 @@
             gap: 1rem;
         }
 
-        .proposalsLists {
+        .proposalListsContainer {
             display: flex;
             flex-direction: row;
             justify-content: space-evenly;
@@ -20,7 +20,7 @@
     </ui:style>
     <g:HTMLPanel styleName="{style.deckLayout}">
         <h1>User exchange proposals</h1>
-        <div class="{style.proposalsLists}">
+        <div class="{style.proposalListsContainer}">
             <m:ProposalListWidget ui:field="fromYouProposalList"/>
             <m:ProposalListWidget ui:field="toYouProposalList"/>
         </div>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
@@ -1,0 +1,58 @@
+package com.aadm.cardexchange.client.widgets;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.*;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Widget;
+
+public class ProposalListWidget extends Composite {
+    private static final ProposalListUiBinder uiBinder = GWT.create(ProposalListUiBinder.class);
+    @UiField
+    HeadingElement tableHeading;
+    @UiField(provided = true)
+    FlexTable table;
+
+    public ProposalListWidget(String title, String otherUser) {
+        setupTable(otherUser);
+        initWidget(uiBinder.createAndBindUi(this));
+        tableHeading.setInnerText(title);
+    }
+
+    private void setupTable(String otherUser) {
+        table = new FlexTable();
+        TableSectionElement tHead = ((TableElement) ((Element) table.getElement())).createTHead();
+        TableRowElement row = tHead.insertRow(0);
+        row.insertCell(0).setInnerText("ID");
+        row.insertCell(1).setInnerText("Date");
+        row.insertCell(2).setInnerText(otherUser);
+        addRow("12212", "08-02-2023", "alessiacrimaldi@virgilio.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+        addRow("12212", "08-02-2023", "test@test.it");
+    }
+
+    private void addRow(String ID, String date, String email) {
+        int numRows = (table.getRowCount());
+        table.setText(numRows, 0, ID);
+        table.setText(numRows, 1, date);
+        table.setText(numRows, 2, email);
+    }
+
+    interface ProposalListUiBinder extends UiBinder<Widget, ProposalListWidget> {
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
@@ -48,6 +48,10 @@ public class ProposalListWidget extends Composite {
         });
     }
 
+    public void resetTable() {
+        table.removeAllRows();
+    }
+
     interface ProposalListUiBinder extends UiBinder<Widget, ProposalListWidget> {
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
@@ -1,9 +1,12 @@
 package com.aadm.cardexchange.client.widgets;
 
+import com.aadm.cardexchange.client.handlers.ImperativeHandleProposalList;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.Widget;
@@ -28,29 +31,21 @@ public class ProposalListWidget extends Composite {
         row.insertCell(0).setInnerText("ID");
         row.insertCell(1).setInnerText("Date");
         row.insertCell(2).setInnerText(otherUser);
-        addRow("12212", "08-02-2023", "alessiacrimaldi@virgilio.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
-        addRow("12212", "08-02-2023", "test@test.it");
     }
 
-    private void addRow(String ID, String date, String email) {
+    public void addRow(int id, String date, String email, ImperativeHandleProposalList rowClickHandler) {
         int numRows = (table.getRowCount());
-        table.setText(numRows, 0, ID);
+        table.setText(numRows, 0, String.valueOf(id));
         table.setText(numRows, 1, date);
         table.setText(numRows, 2, email);
+        Element proposalRow = table.getRowFormatter().getElement(numRows);
+        proposalRow.setTitle("view more");
+        DOM.sinkEvents(proposalRow, Event.ONCLICK);
+        DOM.setEventListener(proposalRow, event -> {
+            if (Event.ONCLICK == event.getTypeInt()) {
+                rowClickHandler.onClickProposalRow(id);
+            }
+        });
     }
 
     interface ProposalListUiBinder extends UiBinder<Widget, ProposalListWidget> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
@@ -12,8 +12,9 @@
             text-align: left;
             border-spacing: 0;
             display: block;
-            max-height: 22vh;
+            max-height: 60vh;
             overflow-y: scroll;
+            cursor: pointer;
         }
 
         .table::-webkit-scrollbar {
@@ -24,10 +25,15 @@
             padding: 0.2rem 1rem 0.2rem 0.7rem;
         }
 
+        .table tbody tr:hover {
+            color: #efefef !important;
+            background-color: #20262E !important;
+        }
+
         .table thead {
             position: sticky;
             top: 0;
-            background-color: #ccc;
+            background-color: rgb(205, 88, 136);
             font-weight: bold;
         }
 
@@ -41,7 +47,7 @@
 
         /*noinspection ALL*/
         .table tbody > tr:nth-child\(odd\) {
-            background-color: #eee;
+            background-color: rgba(205, 88, 136, 0.1);
         }
 
         .table tbody > tr:last-child > td:first-child {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
@@ -1,0 +1,59 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+    <ui:style>
+        .tableHeading {
+            text-align: center;
+        }
+
+        .table {
+            border-radius: 5px;
+            box-shadow: 2px 2px 5px #aaa;
+            text-align: left;
+            border-spacing: 0;
+            display: block;
+            max-height: 22vh;
+            overflow-y: scroll;
+        }
+
+        .table::-webkit-scrollbar {
+            display: none;
+        }
+
+        .table th, td {
+            padding: 0.2rem 1rem 0.2rem 0.7rem;
+        }
+
+        .table thead {
+            position: sticky;
+            top: 0;
+            background-color: #ccc;
+            font-weight: bold;
+        }
+
+        .table thead td:first-child {
+            border-top-left-radius: 5px;
+        }
+
+        .table thead td:last-child {
+            border-top-right-radius: 5px;
+        }
+
+        /*noinspection ALL*/
+        .table tbody > tr:nth-child\(odd\) {
+            background-color: #eee;
+        }
+
+        .table tbody > tr:last-child > td:first-child {
+            border-bottom-left-radius: 5px;
+        }
+
+        .table tbody > tr:last-child > td:last-child {
+            border-bottom-right-radius: 5px;
+        }
+    </ui:style>
+    <g:HTMLPanel>
+        <h2 ui:field="tableHeading" class="{style.tableHeading}"/>
+        <g:FlexTable ui:field="table" styleName="{style.table}"/>
+    </g:HTMLPanel>
+</ui:UiBinder>


### PR DESCRIPTION
This PR implements #134 creating an interface for user visualization of sent and received exchange proposals. A widget named `ProposalListWidget` has been created for displaying the two lists of proposals 'From you' and 'To you', passing them the appropriate parameters (the title, the other user type and the list of proposals contained). The rows of the two tables show a tooltip when the mouse is over and are clickable. For now, the onClickProposalRow is a dummy method which shows an informative alert and takes the id of the proposal as parameter: this will be useful in task #136 when the user will be navigated to the Proposal Page.