### PR TITLE
[UC05#155#156] Added functionality for users to add own physical cards to one of theirs custom decks

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCustomDeck.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandleCustomDeck.java
@@ -8,5 +8,5 @@ import java.util.function.Consumer;
 public interface ImperativeHandleCustomDeck {
     void onClickRemoveCustomDeck(String deck, Consumer<Boolean> isRemoved);
 
-    void onClickAddPhysicalCardsToCustomDeck(Consumer<List<PhysicalCardWithName>> getSelectedPhysicalCards);
+    void onClickAddPhysicalCardsToCustomDeck(String deckName, Consumer<List<PhysicalCardWithName>> getSelectedPhysicalCards);
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -5,6 +5,7 @@ import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.DecksView;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
@@ -150,7 +151,34 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
     }
 
     @Override
-    public void addPhysicalCardsToCustomDeck(List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck) {
+    public void addPhysicalCardsToCustomDeck(String deckName, List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck) {
+        if (checkDeckNameInvalidity(deckName)) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
+        if (pCards.isEmpty()) {
+            view.displayAlert("Empty list of physical cards");
+            return;
+        }
 
+        rpcService.addPhysicalCardsToCustomDeck(authSubject.getToken(), deckName, pCards, new AsyncCallback<List<PhysicalCardWithName>>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else if (caught instanceof InputException) {
+                    view.displayAlert(((InputException) caught).getErrorMessage());
+                } else if (caught instanceof DeckNotFoundException) {
+                    view.displayAlert(((DeckNotFoundException) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
+
+            @Override
+            public void onSuccess(List<PhysicalCardWithName> result) {
+                updateCustomDeck.accept(result);
+            }
+        });
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -31,6 +31,6 @@ public interface DecksView extends IsWidget {
 
         void deleteCustomDeck(String deckName, Consumer<Boolean> isRemoved);
 
-        void addPhysicalCardsToCustomDeck(List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck);
+        void addPhysicalCardsToCustomDeck(String deckName, List<PhysicalCard> pCards, Consumer<List<PhysicalCardWithName>> updateCustomDeck);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
 public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleCustomDeck,
         ImperativeHandlePhysicalCardSelection, ImperativeHandlePhysicalCardEdit {
     private static final DecksViewImpl.DecksViewImplUIBinder uiBinder = GWT.create(DecksViewImpl.DecksViewImplUIBinder.class);
-    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here name for your new custom deck";
+    private static final String DEFAULT_CUSTOM_DECK_TEXT = "Write here your custom deck name";
     Presenter presenter;
     @UiField
     HTMLPanel decksContainer;
@@ -61,6 +61,7 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     public void displayAddedCustomDeck(String deckName) {
         decksContainer.add(createDeck(deckName));
         newDeckName.setInnerText(DEFAULT_CUSTOM_DECK_TEXT);
+        onChangeSelection();
     }
 
     // factory
@@ -85,8 +86,8 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     }
 
     @Override
-    public void onClickAddPhysicalCardsToCustomDeck(Consumer<List<PhysicalCardWithName>> updateCustomDeck) {
-        presenter.addPhysicalCardsToCustomDeck(ownedDeck.getDeckSelectedCards(), updateCustomDeck);
+    public void onClickAddPhysicalCardsToCustomDeck(String deckName, Consumer<List<PhysicalCardWithName>> updateCustomDeck) {
+        presenter.addPhysicalCardsToCustomDeck(deckName, ownedDeck.getDeckSelectedCards(), updateCustomDeck);
     }
 
     @Override
@@ -97,7 +98,6 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     @UiHandler(value = "newDeckButton")
     public void onClickCustomDeckAdd(ClickEvent e) {
         presenter.createCustomDeck(newDeckName.getInnerText());
-        onChangeSelection();
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.ui.xml
@@ -24,7 +24,7 @@
         <h1>User decks</h1>
         <g:HTMLPanel ui:field="decksContainer"/>
         <div class="{style.newDeck}">
-            <h2 ui:field="newDeckName" contenteditable="true">Write here name for your custom deck</h2>
+            <h2 ui:field="newDeckName" contenteditable="true">Write here your custom deck name</h2>
             <g:Button ui:field="newDeckButton" styleName="deckButton">&#10003;</g:Button>
         </div>
     </g:HTMLPanel>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -18,6 +18,7 @@ import com.google.gwt.user.client.ui.Widget;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 
 public class DeckWidget extends Composite implements ImperativeHandlePhysicalCardSelection, ImperativeHandlePhysicalCardRemove, ImperativeHandlePhysicalCardEdit {
     private static final DeckUIBinder uiBinder = GWT.create(DeckUIBinder.class);
@@ -59,7 +60,8 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
 
         if (customDeckHandler != null) {
             addButton = new Button("&#43;", (ClickHandler) e -> {
-                customDeckHandler.onClickAddPhysicalCardsToCustomDeck(pCards -> setData(pCards, null));
+                customDeckHandler.onClickAddPhysicalCardsToCustomDeck(deckName.getInnerText(),
+                        pCards -> setData(pCards, null));
             });
             Button removeButton = new Button("x", (ClickHandler) e -> {
                 if (Window.confirm("Are you sure you want to remove this deck?"))
@@ -80,6 +82,7 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     }
 
     public void setData(List<PhysicalCardWithName> data, String selectedCardId) {
+        Logger.getLogger("adsasd").info(data.toString());
         cards.clear();
         for (PhysicalCardWithName pCard : data) {
             PhysicalCardWidget pCardWidget = createPhysicalCardWidget(pCard);

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.ui.xml
@@ -10,9 +10,15 @@
 
         .deckHeader {
             display: flex;
+            justify-content: space-between;
             align-items: center;
             color: #fff;
-            padding-left: 1rem;
+            padding: 0 1rem 0 1rem;
+        }
+
+        .deckNameWrapper {
+            display: flex;
+            align-items: center;
             gap: 1rem;
         }
 
@@ -40,9 +46,12 @@
     </ui:style>
     <g:HTMLPanel styleName="{style.deck}">
         <div class="{style.deckHeader}">
-            <h2 ui:field="deckName"/>
-            <g:HTMLPanel styleName="{style.actions}" ui:field="actions">
+            <div class="{style.deckNameWrapper}">
+                <h2 ui:field="deckName"/>
                 <g:Button styleName="deckButton {style.showButton}" ui:field="showButton">></g:Button>
+            </div>
+            <g:HTMLPanel styleName="{style.actions}" ui:field="actions">
+                <!--                <g:Button styleName="deckButton {style.showButton}" ui:field="showButton">></g:Button>-->
             </g:HTMLPanel>
         </div>
         <g:HTMLPanel styleName="{style.cards}" ui:field="cards"/>

--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -188,6 +188,12 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         return getPhysicalCardByCardIdAndDeckName(cardId, OWNED_DECK);
     }
 
+    @Override
+    public List<PhysicalCardWithEmail> getWishedPhysicalCardsByCardId(int cardId) throws InputException {
+        CardServiceImpl.checkCardIdInvalidity(cardId);
+        return getPhysicalCardByCardIdAndDeckName(cardId, WISHED_DECK);
+    }
+
     private List<PhysicalCardWithName> joinPhysicalCardsWithCatalogCards(Set<PhysicalCard> pCards) {
         List<PhysicalCardWithName> pCardsWithName = new LinkedList<>();
         for (PhysicalCard pCard : pCards) {
@@ -223,11 +229,5 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         deckMap.put(customDeckName, userDecks);
         // Return the modified deck's card list
         return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
-    }
-
-    @Override
-    public List<PhysicalCardWithEmail> getWishedPhysicalCardsByCardId(int cardId) throws InputException {
-        CardServiceImpl.checkCardIdInvalidity(cardId);
-        return getPhysicalCardByCardIdAndDeckName(cardId, WISHED_DECK);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -6,6 +6,7 @@ import com.aadm.cardexchange.server.mapdb.MapDBConstants;
 import com.aadm.cardexchange.server.mapdb.MapDBImpl;
 import com.aadm.cardexchange.shared.DeckService;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.*;
 import com.google.common.reflect.TypeToken;
@@ -24,7 +25,8 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
     private static final String WISHED_DECK = "Wished";
     private final MapDB db;
     private final Gson gson = new Gson();
-    private final Type type = new TypeToken<Map<String, Deck>>() {}.getType();
+    private final Type type = new TypeToken<Map<String, Deck>>() {
+    }.getType();
 
     public DeckServiceImpl() {
         db = new MapDBImpl();
@@ -151,22 +153,9 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
 
     private List<PhysicalCardWithName> getUserDeck(String userEmail, String deckName) {
         Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
-        Map<String, Deck> allUserDecks = deckMap.get(userEmail);
-        Deck userDeck = allUserDecks.get(deckName);
-        List<PhysicalCardWithName> pCardsWithName = new ArrayList<>();
-        for (PhysicalCard pCard : userDeck.getPhysicalCards()) {
-            String cardName = CardServiceImpl.getNameCard(
-                    pCard.getCardId(),
-                    db.getCachedMap(
-                            getServletContext(),
-                            CardServiceImpl.getCardMap(pCard.getGameType()),
-                            Serializer.INTEGER,
-                            new GsonSerializer<>(gson)
-                    )
-            );
-            pCardsWithName.add(new PhysicalCardWithName(pCard, cardName));
-        }
-        return pCardsWithName;
+        Map<String, Deck> userDecks = deckMap.get(userEmail);
+        Deck userDeck = userDecks.get(deckName);
+        return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
     }
 
     @Override
@@ -203,5 +192,42 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
             throw new InputException("Invalid cardId");
         }
         return getPhysicalCardByCardIdAndDeckName(cardId, OWNED_DECK);
+    }
+
+    private List<PhysicalCardWithName> joinPhysicalCardsWithCatalogCards(Set<PhysicalCard> pCards) {
+        List<PhysicalCardWithName> pCardsWithName = new LinkedList<>();
+        for (PhysicalCard pCard : pCards) {
+            pCardsWithName.add(new PhysicalCardWithName(
+                    pCard,
+                    CardServiceImpl.getNameCard(pCard.getCardId(), db.getCachedMap(
+                            getServletContext(),
+                            CardServiceImpl.getCardMap(pCard.getGameType()),
+                            Serializer.INTEGER,
+                            new GsonSerializer<>(gson)
+                    ))
+            ));
+        }
+        return pCardsWithName;
+    }
+
+    @Override
+    public List<PhysicalCardWithName> addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards) throws AuthException, InputException, DeckNotFoundException {
+        String userEmail = AuthServiceImpl.checkTokenValidity(token,
+                db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
+        if (customDeckName == null || customDeckName.isEmpty())
+            throw new InputException("Invalid deck name");
+        if (customDeckName.equals(OWNED_DECK) || customDeckName.equals(WISHED_DECK))
+            throw new InputException("Default deck names not allowed for custom deck");
+        if (pCards.isEmpty())
+            throw new InputException("Empty list of physical cards");
+        Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
+        Map<String, Deck> userDecks = deckMap.get(userEmail);
+        Deck userDeck = userDecks.get(customDeckName);
+        if (userDeck == null)
+            throw new DeckNotFoundException("Custom deck '" + customDeckName + "' not found.");
+        pCards.forEach(userDeck::addPhysicalCard);
+        deckMap.put(customDeckName, userDecks);
+        // Return the modified deck's card list
+        return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
     }
 }

--- a/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/DeckServiceImpl.java
@@ -37,7 +37,7 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
     }
 
     private static boolean addDeck(String email, String deckName, boolean isDefault, Map<String, Map<String, Deck>> deckMap) {
-        Map<String, Deck> userDecks = deckMap.computeIfAbsent(email, k -> new HashMap<>());
+        Map<String, Deck> userDecks = deckMap.computeIfAbsent(email, k -> new LinkedHashMap<>());
         // if deck already exists in decks container do nothing
         if (userDecks.get(deckName) != null) {
             return false;
@@ -129,7 +129,7 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
             throw new InputException("Invalid deck name");
         }
         Map<String, Map<String, Deck>> deckMap = db.getPersistentMap(getServletContext(), DECK_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson, type));
-        Map<String, Deck> decks = new HashMap<>(deckMap.get(userEmail));
+        Map<String, Deck> decks = new LinkedHashMap<>(deckMap.get(userEmail));
         if (decks.size() == 0) {
             throw new RuntimeException("Not existing decks");
         }
@@ -226,7 +226,7 @@ public class DeckServiceImpl extends RemoteServiceServlet implements DeckService
         if (userDeck == null)
             throw new DeckNotFoundException("Custom deck '" + customDeckName + "' not found.");
         pCards.forEach(userDeck::addPhysicalCard);
-        deckMap.put(customDeckName, userDecks);
+        deckMap.put(userEmail, userDecks);
         // Return the modified deck's card list
         return joinPhysicalCardsWithCatalogCards(userDeck.getPhysicalCards());
     }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckService.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckService.java
@@ -27,4 +27,6 @@ public interface DeckService extends RemoteService {
     List<PhysicalCardWithName> getUserOwnedDeck(String email) throws AuthException;
 
     List<PhysicalCardWithEmail> getOwnedPhysicalCardsByCardId(int cardId) throws InputException;
+
+    List<PhysicalCardWithName> addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards) throws BaseException;
 }

--- a/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
+++ b/src/main/java/com/aadm/cardexchange/shared/DeckServiceAsync.java
@@ -21,4 +21,6 @@ public interface DeckServiceAsync {
     void getUserOwnedDeck(String email, AsyncCallback<List<PhysicalCardWithName>> callback);
 
     void getOwnedPhysicalCardsByCardId(int cardId, AsyncCallback<List<PhysicalCardWithEmail>> callback);
+
+    void addPhysicalCardsToCustomDeck(String token, String customDeckName, List<PhysicalCard> pCards, AsyncCallback<List<PhysicalCardWithName>> callback);
 }

--- a/src/main/java/com/aadm/cardexchange/shared/exceptions/DeckNotFoundException.java
+++ b/src/main/java/com/aadm/cardexchange/shared/exceptions/DeckNotFoundException.java
@@ -1,0 +1,13 @@
+package com.aadm.cardexchange.shared.exceptions;
+
+
+public class DeckNotFoundException extends BaseException {
+    private static final long serialVersionUID = -9069721007995377785L;
+
+    public DeckNotFoundException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public DeckNotFoundException() {
+    }
+}

--- a/src/main/java/com/aadm/cardexchange/shared/models/Status.java
+++ b/src/main/java/com/aadm/cardexchange/shared/models/Status.java
@@ -25,11 +25,13 @@ public enum Status {
                                         value == 5 ? Excellent :
                                                 null;
     }
+
     private static final List<Status> VALUES =
             Collections.unmodifiableList(Arrays.asList(values()));
     private static final int SIZE = VALUES.size();
     private static final Random RANDOM = new Random();
-    public static Status randomGame()  {
+
+    public static Status randomStatus() {
         return VALUES.get(RANDOM.nextInt(SIZE));
     }
 

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -6,6 +6,7 @@ import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.DecksView;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
+import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.Game;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
@@ -20,7 +21,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.easymock.EasyMock.*;
@@ -68,6 +72,7 @@ public class DecksActivityTest {
         return Stream.of(
                 Arguments.of(new AuthException("Invalid token")),
                 Arguments.of(new InputException("Invalid description")),
+                Arguments.of(new DeckNotFoundException("Dec")),
                 Arguments.of(new RuntimeException())
         );
     }
@@ -237,6 +242,80 @@ public class DecksActivityTest {
 
         ctrl.replay();
         decksActivity.deleteCustomDeck("Test", Assertions::assertTrue);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testAddPhysicalCardsToCustomDeckForInvalidDeckName(String input) {
+        List<PhysicalCard> mockPCards = Arrays.asList(
+                new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description."),
+                new PhysicalCard(Game.randomGame(), 2222, Status.randomStatus(), "This is a valid description.")
+        );
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.addPhysicalCardsToCustomDeck(input, mockPCards, (pCardsWithName -> {
+        }));
+        ctrl.verify();
+    }
+
+    @Test
+    public void testAddPhysicalCardsToCustomDeckForEmptyList() {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.addPhysicalCardsToCustomDeck("test", Collections.emptyList(), (pCardsWithName) -> {
+        });
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testAddPhysicalCardsToCustomDeckForValidParametersForFailure(Exception e) {
+        // init mocks
+        List<PhysicalCard> mockPCards = Arrays.asList(
+                new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description."),
+                new PhysicalCard(Game.randomGame(), 2222, Status.randomStatus(), "This is a valid description.")
+        );
+
+        // expects
+        mockRpcService.addPhysicalCardsToCustomDeck(anyString(), anyString(), isA(List.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<List<PhysicalCardWithName>> callback = (AsyncCallback<List<PhysicalCardWithName>>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+
+        ctrl.replay();
+        decksActivity.addPhysicalCardsToCustomDeck("test", mockPCards, (pCardsWithName) -> {
+        });
+        ctrl.verify();
+    }
+
+    @Test
+    public void testAddPhysicalCardsToCustomDeckForValidParametersForSuccess() {
+        // init mocks
+        PhysicalCard mockPCard1 = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description.");
+        PhysicalCard mockPCard2 = new PhysicalCard(Game.randomGame(), 2222, Status.randomStatus(), "This is a valid description.");
+        List<PhysicalCard> mockPCards = Arrays.asList(mockPCard1, mockPCard2);
+        List<PhysicalCardWithName> mockPCardsWithName = Arrays.asList(
+                new PhysicalCardWithName(mockPCard1, "Charizard"),
+                new PhysicalCardWithName(mockPCard2, "Blastoise"));
+        Consumer<List<PhysicalCardWithName>> consumer = ctrl.createMock(Consumer.class);
+
+        // expects
+        mockRpcService.addPhysicalCardsToCustomDeck(anyString(), anyString(), isA(List.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<List<PhysicalCardWithName>> callback = (AsyncCallback<List<PhysicalCardWithName>>) args[args.length - 1];
+            callback.onSuccess(mockPCardsWithName);
+            return null;
+        });
+        consumer.accept(mockPCardsWithName);
+
+        ctrl.replay();
+        decksActivity.addPhysicalCardsToCustomDeck("test", mockPCards, consumer);
         ctrl.verify();
     }
 }

--- a/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
@@ -370,10 +370,10 @@ public class DeckServiceTest {
     }
 
     private void setupDefaultDecks(String deckName, String mail1, String mail2) {
-        PhysicalCard mockPCard1 = new PhysicalCard(Game.randomGame(), 1111, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard2 = new PhysicalCard(Game.randomGame(), 1111, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard3 = new PhysicalCard(Game.randomGame(), 2222, Status.randomGame(), "This is the card that I want.");
-        PhysicalCard mockPCard4 = new PhysicalCard(Game.randomGame(), 3333, Status.randomGame(), "This is the card that I want.");
+        PhysicalCard mockPCard1 = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard2 = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard3 = new PhysicalCard(Game.randomGame(), 2222, Status.randomStatus(), "This is the card that I want.");
+        PhysicalCard mockPCard4 = new PhysicalCard(Game.randomGame(), 3333, Status.randomStatus(), "This is the card that I want.");
         Deck mockDeck1 = new Deck(deckName, true);
         Deck mockDeck2 = new Deck(deckName, true);
 
@@ -444,7 +444,7 @@ public class DeckServiceTest {
         // init Mocks
         String emailTest1 = "test1@test.it";
         String emailTest2 = "test2@test.it";
-        setupDefaultDecks("Owned",  emailTest1,  emailTest2);
+        setupDefaultDecks("Owned", emailTest1, emailTest2);
         ctrl.replay();
         List<PhysicalCardWithEmail> pCardsWithEmail = deckService.getOwnedPhysicalCardsByCardId(1111);
         ctrl.verify();
@@ -558,7 +558,7 @@ public class DeckServiceTest {
         // init mocks
         String emailTest1 = "test1@test.it";
         String emailTest2 = "test2@test.it";
-        setupDefaultDecks("Wished",  emailTest1,  emailTest2);
+        setupDefaultDecks("Wished", emailTest1, emailTest2);
 
         ctrl.replay();
         List<PhysicalCardWithEmail> pCardsWithEmail = deckService.getWishedPhysicalCardsByCardId(1111);

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -61,7 +61,7 @@ public class ExchangeServiceTest {
     private List<PhysicalCard> generateValidListPcard(int n) {
         List<PhysicalCard> myList = new ArrayList<>();
         for (int i = 0; i < n; i++) {
-            PhysicalCard mockPCard = new PhysicalCard(Game.randomGame(), (i + 3000), Status.randomGame(), "This is a valid description.");
+            PhysicalCard mockPCard = new PhysicalCard(Game.randomGame(), (i + 3000), Status.randomStatus(), "This is a valid description.");
             myList.add(mockPCard);
         }
         return myList;
@@ -103,7 +103,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForEmptySenderPCards() throws AuthException {
+    public void testAddProposalForEmptySenderPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -112,7 +112,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForNullSenderPCards() throws AuthException {
+    public void testAddProposalForNullSenderPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -121,7 +121,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForEmptyReceiverPCards() throws AuthException {
+    public void testAddProposalForEmptyReceiverPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();
@@ -130,7 +130,7 @@ public class ExchangeServiceTest {
     }
 
     @Test
-    public void testAddProposalForNullReceiverPCards() throws AuthException {
+    public void testAddProposalForNullReceiverPCards() {
         setupForValidToken();
         setupForValidEmail();
         ctrl.replay();


### PR DESCRIPTION
This PR implements #155, #156 and adds a new method called `addPhysicalCardsToCustomDeck` in the DecksActivity to add owned physical cards to a custom deck via RPC call. Additionally, the decks collection has been changed from a HashMap to a LinkedHashMap to ensure the ordering of keys (and thus deck names).
Tests for the new method were also added.

Oopsie Doopsie, we've reached 300 tests 🚀