### PR TITLE
[UC13#161#173] Added functionality for users to edit one of theirs owned or wished physical card

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardEdit.java
+++ b/src/main/java/com/aadm/cardexchange/client/handlers/ImperativeHandlePhysicalCardEdit.java
@@ -1,5 +1,7 @@
 package com.aadm.cardexchange.client.handlers;
 
+import com.aadm.cardexchange.shared.models.PhysicalCard;
+
 public interface ImperativeHandlePhysicalCardEdit {
-    void onConfirmCardEdit();
+    void onConfirmCardEdit(String deckName, PhysicalCard editedPcard);
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/DecksActivity.java
@@ -6,9 +6,11 @@ import com.aadm.cardexchange.client.views.DecksView;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
 import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
+import com.aadm.cardexchange.shared.exceptions.ExistingProposal;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
+import com.aadm.cardexchange.shared.payloads.ModifiedDeckPayload;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -61,8 +63,38 @@ public class DecksActivity extends AbstractActivity implements DecksView.Present
     }
 
     @Override
-    public void updatePhysicalCard() {
+    public void updatePhysicalCard(String deckName, PhysicalCard editedPcard) {
+        if (checkDeckNameInvalidity(deckName)) {
+            view.displayAlert("Invalid deck name");
+            return;
+        }
+        if (!deckName.equals("Owned") && !deckName.equals("Wished")) {
+            view.displayAlert("Sorry, you can only edit physical cards in Default decks.");
+            return;
+        }
+        if (editedPcard == null) {
+            view.displayAlert("Invalid physical card");
+            return;
+        }
+        rpcService.editPhysicalCard(authSubject.getToken(), deckName, editedPcard, new AsyncCallback<List<ModifiedDeckPayload>>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                if (caught instanceof AuthException) {
+                    view.displayAlert(((AuthException) caught).getErrorMessage());
+                } else if (caught instanceof InputException) {
+                    view.displayAlert(((InputException) caught).getErrorMessage());
+                } else if (caught instanceof ExistingProposal) {
+                    view.displayAlert(((ExistingProposal) caught).getErrorMessage());
+                } else {
+                    view.displayAlert("Internal server error: " + caught.getMessage());
+                }
+            }
 
+            @Override
+            public void onSuccess(List<ModifiedDeckPayload> result) {
+                view.replaceData(result);
+            }
+        });
     }
 
     private boolean checkDeckNameInvalidity(String deckName) {

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksView.java
@@ -2,6 +2,7 @@ package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
+import com.aadm.cardexchange.shared.payloads.ModifiedDeckPayload;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
@@ -16,6 +17,8 @@ public interface DecksView extends IsWidget {
 
     void displayAlert(String message);
 
+    void replaceData(List<ModifiedDeckPayload> data);
+
     void displayAddedCustomDeck(String deckName);
 
     void setPresenter(Presenter presenter);
@@ -23,7 +26,7 @@ public interface DecksView extends IsWidget {
     interface Presenter {
         void fetchUserDeck(String deckName, BiConsumer<List<PhysicalCardWithName>, String> setDeckData);
 
-        void updatePhysicalCard();
+        void updatePhysicalCard(String deckName, PhysicalCard editedPcard);
 
         void removePhysicalCardFromDeck(String deckName, PhysicalCard pCard, Consumer<Boolean> isRemoved);
 

--- a/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/DecksViewImpl.java
@@ -7,6 +7,7 @@ import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardSelecti
 import com.aadm.cardexchange.client.widgets.DeckWidget;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
+import com.aadm.cardexchange.shared.payloads.ModifiedDeckPayload;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -19,8 +20,11 @@ import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class DecksViewImpl extends Composite implements DecksView, ImperativeHandleDeck, ImperativeHandleCustomDeck,
         ImperativeHandlePhysicalCardSelection, ImperativeHandlePhysicalCardEdit {
@@ -55,6 +59,17 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     @Override
     public void displayAlert(String message) {
         Window.alert(message);
+    }
+
+    @Override
+    public void replaceData(List<ModifiedDeckPayload> data) {
+        Map<String, ModifiedDeckPayload> lookup = data.stream()
+                .collect(Collectors.toMap(ModifiedDeckPayload::getDeckName, Function.identity()));
+        decksContainer.forEach(w -> {
+            DeckWidget deckWidget = ((DeckWidget) w);
+            ModifiedDeckPayload modifiedDeck = lookup.get(deckWidget.getDeckName());
+            if (modifiedDeck != null) deckWidget.setData(modifiedDeck.getPhysicalCardsWithName(), null);
+        });
     }
 
     @Override
@@ -106,8 +121,8 @@ public class DecksViewImpl extends Composite implements DecksView, ImperativeHan
     }
 
     @Override
-    public void onConfirmCardEdit() {
-        presenter.updatePhysicalCard();
+    public void onConfirmCardEdit(String deckName, PhysicalCard editedPcard) {
+        presenter.updatePhysicalCard(deckName, editedPcard);
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/DeckWidget.java
@@ -101,6 +101,10 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
         );
     }
 
+    public String getDeckName() {
+        return deckName.getInnerText();
+    }
+
     public void setDeckName(String name) {
         deckName.setInnerText(name);
     }
@@ -141,8 +145,8 @@ public class DeckWidget extends Composite implements ImperativeHandlePhysicalCar
     }
 
     @Override
-    public void onConfirmCardEdit() {
-        cardEditHandler.onConfirmCardEdit();
+    public void onConfirmCardEdit(String deckName, PhysicalCard editedPcard) {
+        cardEditHandler.onConfirmCardEdit(this.deckName.getInnerText(), editedPcard);
     }
 
     interface DeckUIBinder extends UiBinder<Widget, DeckWidget> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/PhysicalCardWidget.java
@@ -4,6 +4,7 @@ import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardEdit;
 import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardRemove;
 import com.aadm.cardexchange.client.handlers.ImperativeHandlePhysicalCardSelection;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
+import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.HeadingElement;
@@ -53,8 +54,13 @@ public class PhysicalCardWidget extends Composite {
         if (editHandler != null) {
             editButton = new Button("&#9998", (ClickHandler) e -> {
                 e.stopPropagation();
+                if (isEditable) {
+                    editHandler.onConfirmCardEdit(null, pCard.copyWithModifiedStatusAndDescription(
+                            Status.getStatus(Integer.parseInt(((StatusWidget) cardStatus.getWidget(0)).getSelection())),
+                            cardDescription.getInnerText()
+                    ));
+                }
                 toggleEditMode();
-                editHandler.onConfirmCardEdit();
             });
             editButton.setStyleName(style.editButton());
             cardActions.add(editButton);
@@ -121,7 +127,6 @@ public class PhysicalCardWidget extends Composite {
     }
 
     interface PhysicalCardStyle extends CssResource {
-
         String cardSelected();
 
         String deleteButton();

--- a/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
@@ -17,6 +17,7 @@ public class SidebarWidget extends Composite implements RouteConstants {
     public SidebarWidget(ImperativeHandleSidebar parent) {
         initWidget(uiBinder.createAndBindUi(this));
         button = new Button("Logout", (ClickHandler) event -> parent.onClickLogout());
+        button.setStyleName("");
     }
 
     public void setLinks(boolean isLoggedIn) {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.ui.xml
@@ -7,16 +7,38 @@
             position: sticky;
             top: 0;
             display: flex;
+            gap: 2rem;
             flex-direction: column;
             justify-content: center;
             align-items: center;
             background: #20262E;
         }
 
-        .sidebar div {
-            background: #E9E8E8;
-            margin: 1rem;
+        .sidebar > div, .sidebar > button {
+            display: flex;
+            justify-content: center;
+            width: 6rem;
+            background-color: #eee;
+            border: 0;
+            border-radius: 4px;
+            font-family: "Inter var", ui-sans-serif, system-ui, -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+            font-size: 1.1em;
+            font-weight: 500;
             padding: 1rem;
+        }
+
+
+        .sidebar > div:hover, .sidebar > button:hover {
+            background-color: #fff;
+        }
+
+        .sidebar > div > a {
+            color: #444;
+            text-decoration: none;
+        }
+
+        .sidebar > button {
+            color: #f03a3a;
         }
     </ui:style>
     <g:HTMLPanel styleName="{style.sidebar}" ui:field="links"/>

--- a/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/DecksActivityTest.java
@@ -4,14 +4,17 @@ import com.aadm.cardexchange.client.auth.AuthSubject;
 import com.aadm.cardexchange.client.presenters.DecksActivity;
 import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.DecksView;
+import com.aadm.cardexchange.server.DummyData;
 import com.aadm.cardexchange.shared.DeckServiceAsync;
 import com.aadm.cardexchange.shared.exceptions.AuthException;
 import com.aadm.cardexchange.shared.exceptions.DeckNotFoundException;
+import com.aadm.cardexchange.shared.exceptions.ExistingProposal;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.Game;
 import com.aadm.cardexchange.shared.models.PhysicalCard;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithName;
 import com.aadm.cardexchange.shared.models.Status;
+import com.aadm.cardexchange.shared.payloads.ModifiedDeckPayload;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.easymock.IMocksControl;
 import org.junit.jupiter.api.Assertions;
@@ -72,7 +75,8 @@ public class DecksActivityTest {
         return Stream.of(
                 Arguments.of(new AuthException("Invalid token")),
                 Arguments.of(new InputException("Invalid description")),
-                Arguments.of(new DeckNotFoundException("Dec")),
+                Arguments.of(new DeckNotFoundException("Deck not found")),
+                Arguments.of(new ExistingProposal("Physical card edit/remove is not allowed as it already exists in a proposal.")),
                 Arguments.of(new RuntimeException())
         );
     }
@@ -316,6 +320,74 @@ public class DecksActivityTest {
 
         ctrl.replay();
         decksActivity.addPhysicalCardsToCustomDeck("test", mockPCards, consumer);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"Custom"})
+    public void testUpdatePhysicalCardForInvalidDeckName(String input) {
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.updatePhysicalCard(input, new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description."));
+        ctrl.verify();
+    }
+
+    @Test
+    public void testUpdatePhysicalCardForNullPhysicalCard() {
+        mockDecksView.displayAlert("Invalid physical card");
+        ctrl.replay();
+        decksActivity.updatePhysicalCard("Owned", null);
+        ctrl.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDifferentTypeOfErrors")
+    public void testUpdatePhysicalCardForValidParametersForFailure(Exception e) {
+        mockRpcService.editPhysicalCard(anyString(), anyString(), isA(PhysicalCard.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<List<ModifiedDeckPayload>> callback = (AsyncCallback<List<ModifiedDeckPayload>>) args[args.length - 1];
+            callback.onFailure(e);
+            return null;
+        });
+        mockDecksView.displayAlert(anyString());
+        ctrl.replay();
+        decksActivity.updatePhysicalCard("Owned", new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description."));
+        ctrl.verify();
+    }
+
+    @Test
+    public void testUpdatePhysicalCardForValidParametersForSuccess() {
+        // init mocks
+        PhysicalCard editedPCard = new PhysicalCard(Game.randomGame(), 1111, Status.randomStatus(), "This is a valid description.")
+                .copyWithModifiedStatusAndDescription(Status.Excellent, "This is an edited description");
+        PhysicalCardWithName editedPCardWithName = new PhysicalCardWithName(editedPCard, "test");
+
+        List<PhysicalCardWithName> mockPCards1 = DummyData.createPhysicalCardWithNameDummyList(5);
+        List<PhysicalCardWithName> mockPCards2 = DummyData.createPhysicalCardWithNameDummyList(5);
+
+        mockPCards1.addAll(mockPCards2);
+        mockPCards1.add(editedPCardWithName);
+        mockPCards2.add(editedPCardWithName);
+
+        List<ModifiedDeckPayload> modifiedDecks = Arrays.asList(
+                new ModifiedDeckPayload("Owned", mockPCards1),
+                new ModifiedDeckPayload("Custom", mockPCards2)
+        );
+
+        // expects
+        mockRpcService.editPhysicalCard(anyString(), anyString(), isA(PhysicalCard.class), isA(AsyncCallback.class));
+        expectLastCall().andAnswer(() -> {
+            Object[] args = getCurrentArguments();
+            AsyncCallback<List<ModifiedDeckPayload>> callback = (AsyncCallback<List<ModifiedDeckPayload>>) args[args.length - 1];
+            callback.onSuccess(modifiedDecks);
+            return null;
+        });
+        mockDecksView.replaceData(isA(List.class));
+
+        ctrl.replay();
+        decksActivity.updatePhysicalCard("Owned", editedPCard);
         ctrl.verify();
     }
 }

--- a/src/test/java/com/aadm/cardexchange/server/DummyData.java
+++ b/src/test/java/com/aadm/cardexchange/server/DummyData.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 // Create dummy cards with distinct fields for testing purposes
 public class DummyData {
@@ -103,5 +104,9 @@ public class DummyData {
         for (int i = 0; i < n; i++)
             list.add(new PhysicalCard(Game.randomGame(), (i + 3000), Status.randomStatus(), "This is a valid description."));
         return list;
+    }
+
+    public static List<PhysicalCardWithName> createPhysicalCardWithNameDummyList(int n) {
+        return createPhysicalCardDummyList(n).stream().map(pCard -> new PhysicalCardWithName(pCard, "test")).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
This PR implements #161, #173 and adds a new method called `updatePhysicalCard` in the DecksActivity to edit status and description of one of user's wished/owned physical card. 
Once a physical card is edited, all decks that contains that card are updated to reflect new changes.
Additionally, small CSS improvement was done on sidebar buttons.
Supplied with coverage for unit testing.