### PR TITLE
[UC19#135#187] Connected RPC for populating the user exchange proposals lists in the Exchange page

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
@@ -31,7 +31,7 @@ public class ExchangesActivity extends AbstractActivity implements ExchangesView
     }
 
     private void fetchSentProposals() {
-        rpcService.getProposalListSend(authSubject.getToken(), new BaseAsyncCallback<List<Proposal>>() {
+        rpcService.getProposalListSent(authSubject.getToken(), new BaseAsyncCallback<List<Proposal>>() {
             @Override
             public void onSuccess(List<Proposal> proposals) {
                 view.setFromYouProposalList(proposals);

--- a/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
@@ -1,32 +1,51 @@
 package com.aadm.cardexchange.client.presenters;
 
+import com.aadm.cardexchange.client.auth.AuthSubject;
+import com.aadm.cardexchange.client.utils.BaseAsyncCallback;
 import com.aadm.cardexchange.client.views.ExchangesView;
+import com.aadm.cardexchange.shared.ExchangeServiceAsync;
 import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class ExchangesActivity extends AbstractActivity implements ExchangesView.Presenter {
     private final ExchangesView view;
-    List<Proposal> proposals = Arrays.asList(
-            new Proposal("alessiacrimaldi@gmail.com", "alessioarcara@gmail.com", Collections.emptyList(), Collections.emptyList()),
-            new Proposal("matteosacco@gmail.com", "davidefermi@gmail.com", Collections.emptyList(), Collections.emptyList())
-    );
+    private final ExchangeServiceAsync rpcService;
+    private final AuthSubject authSubject;
 
-    public ExchangesActivity(ExchangesView view) {
+    public ExchangesActivity(ExchangesView view, ExchangeServiceAsync rpcService, AuthSubject authSubject) {
         this.view = view;
+        this.rpcService = rpcService;
+        this.authSubject = authSubject;
     }
 
     @Override
     public void start(AcceptsOneWidget acceptsOneWidget, EventBus eventBus) {
         view.setPresenter(this);
         acceptsOneWidget.setWidget(view.asWidget());
-        view.setFromYouProposalList(proposals);
-        view.setToYouProposalList(proposals);
+        fetchSentProposals();
+        fetchReceivedProposals();
+    }
+
+    private void fetchSentProposals() {
+        rpcService.getProposalListSend(authSubject.getToken(), new BaseAsyncCallback<List<Proposal>>() {
+            @Override
+            public void onSuccess(List<Proposal> proposals) {
+                view.setFromYouProposalList(proposals);
+            }
+        });
+    }
+
+    private void fetchReceivedProposals() {
+        rpcService.getProposalListReceived(authSubject.getToken(), new BaseAsyncCallback<List<Proposal>>() {
+            @Override
+            public void onSuccess(List<Proposal> proposals) {
+                view.setToYouProposalList(proposals);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
+++ b/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
@@ -34,7 +34,7 @@ public class AppActivityMapper implements ActivityMapper {
             return new NewExchangeActivity((NewExchangePlace) place, clientFactory.getNewExchangeView(), GWT.create(DeckService.class), GWT.create(ExchangeService.class),
                     clientFactory.getAuthSubject(), clientFactory.getPlaceController());
         if (place instanceof ExchangesPlace && ((ExchangesPlace) place).getProposalId() == null)
-            return new ExchangesActivity(clientFactory.getExchangesView());
+            return new ExchangesActivity(clientFactory.getExchangesView(), GWT.create(ExchangeService.class), clientFactory.getAuthSubject());
         if (place instanceof ExchangesPlace)
             return new ExchangeActivity((ExchangesPlace) place, clientFactory.getNewExchangeView(), GWT.create(ExchangeService.class),
                     clientFactory.getAuthSubject(), clientFactory.getPlaceController());

--- a/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
+++ b/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
@@ -34,7 +34,7 @@ public class AppActivityMapper implements ActivityMapper {
             return new NewExchangeActivity((NewExchangePlace) place, clientFactory.getNewExchangeView(), GWT.create(DeckService.class), GWT.create(ExchangeService.class),
                     clientFactory.getAuthSubject(), clientFactory.getPlaceController());
         if (place instanceof ExchangesPlace)
-            return new ExchangesActivity(clientFactory.getExchangesView());
+            return new ExchangesActivity(clientFactory.getExchangesView(), GWT.create(ExchangeService.class), clientFactory.getAuthSubject());
         return null;
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
@@ -4,12 +4,14 @@ import com.aadm.cardexchange.client.handlers.ImperativeHandleProposalList;
 import com.aadm.cardexchange.client.widgets.ProposalListWidget;
 import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 
+import java.util.Date;
 import java.util.List;
 
 public class ExchangesViewImpl extends Composite implements ExchangesView, ImperativeHandleProposalList {
@@ -28,16 +30,18 @@ public class ExchangesViewImpl extends Composite implements ExchangesView, Imper
 
     @Override
     public void setFromYouProposalList(List<Proposal> proposals) {
-        proposals.forEach(proposal ->
-                fromYouProposalList.addRow(proposal.getId(), "08-02-2023", proposal.getReceiverUserEmail(), this)
-        );
+        proposals.forEach(proposal -> {
+            String proposalDate = DateTimeFormat.getFormat("dd/MM/yyyy").format(new Date(proposal.getDate()));
+            fromYouProposalList.addRow(proposal.getId(), proposalDate, proposal.getReceiverUserEmail(), this);
+        });
     }
 
     @Override
     public void setToYouProposalList(List<Proposal> proposals) {
-        proposals.forEach(proposal ->
-                toYouProposalList.addRow(proposal.getId(), "08-02-2023", proposal.getSenderUserEmail(), this)
-        );
+        proposals.forEach(proposal -> {
+            String proposalDate = DateTimeFormat.getFormat("dd/MM/yyyy").format(new Date(proposal.getDate()));
+            toYouProposalList.addRow(proposal.getId(), proposalDate, proposal.getSenderUserEmail(), this);
+        });
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
@@ -110,4 +110,3 @@ public class ExchangeServiceImpl extends RemoteServiceServlet implements Exchang
         return proposalList;
     }
 }
-


### PR DESCRIPTION
This PR implements #135 and #187 using RPCs to enrich the Exchanges page with the real lists of proposals sent and received by the authenticated user.
Testing the methods were not required cause they're private.