### PR TITLE
[UC19#136] Connected ExchangeProposal page to the click on a proposal row in the proposals lists

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/ExchangesActivity.java
@@ -7,6 +7,8 @@ import com.aadm.cardexchange.shared.ExchangeServiceAsync;
 import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.place.shared.Place;
+import com.google.gwt.place.shared.PlaceController;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 
 import java.util.List;
@@ -15,11 +17,13 @@ public class ExchangesActivity extends AbstractActivity implements ExchangesView
     private final ExchangesView view;
     private final ExchangeServiceAsync rpcService;
     private final AuthSubject authSubject;
+    private final PlaceController placeController;
 
-    public ExchangesActivity(ExchangesView view, ExchangeServiceAsync rpcService, AuthSubject authSubject) {
+    public ExchangesActivity(ExchangesView view, ExchangeServiceAsync rpcService, AuthSubject authSubject, PlaceController placeController) {
         this.view = view;
         this.rpcService = rpcService;
         this.authSubject = authSubject;
+        this.placeController = placeController;
     }
 
     @Override
@@ -46,6 +50,10 @@ public class ExchangesActivity extends AbstractActivity implements ExchangesView
                 view.setToYouProposalList(proposals);
             }
         });
+    }
+
+    public void goTo(Place place) {
+        placeController.goTo(place);
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
+++ b/src/main/java/com/aadm/cardexchange/client/routes/AppActivityMapper.java
@@ -34,7 +34,7 @@ public class AppActivityMapper implements ActivityMapper {
             return new NewExchangeActivity((NewExchangePlace) place, clientFactory.getNewExchangeView(), GWT.create(DeckService.class), GWT.create(ExchangeService.class),
                     clientFactory.getAuthSubject(), clientFactory.getPlaceController());
         if (place instanceof ExchangesPlace && ((ExchangesPlace) place).getProposalId() == null)
-            return new ExchangesActivity(clientFactory.getExchangesView(), GWT.create(ExchangeService.class), clientFactory.getAuthSubject());
+            return new ExchangesActivity(clientFactory.getExchangesView(), GWT.create(ExchangeService.class), clientFactory.getAuthSubject(), clientFactory.getPlaceController());
         if (place instanceof ExchangesPlace)
             return new ExchangeActivity((ExchangesPlace) place, clientFactory.getNewExchangeView(), GWT.create(ExchangeService.class),
                     clientFactory.getAuthSubject(), clientFactory.getPlaceController());

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesView.java
@@ -1,6 +1,7 @@
 package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.shared.models.Proposal;
+import com.google.gwt.place.shared.Place;
 import com.google.gwt.user.client.ui.IsWidget;
 
 import java.util.List;
@@ -15,6 +16,6 @@ public interface ExchangesView extends IsWidget {
     void setPresenter(Presenter presenter);
 
     interface Presenter {
-
+        void goTo(Place place);
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/ExchangesViewImpl.java
@@ -1,13 +1,13 @@
 package com.aadm.cardexchange.client.views;
 
 import com.aadm.cardexchange.client.handlers.ImperativeHandleProposalList;
+import com.aadm.cardexchange.client.places.ExchangesPlace;
 import com.aadm.cardexchange.client.widgets.ProposalListWidget;
 import com.aadm.cardexchange.shared.models.Proposal;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -46,8 +46,7 @@ public class ExchangesViewImpl extends Composite implements ExchangesView, Imper
 
     @Override
     public void onClickProposalRow(int selectedProposalId) {
-        // There will be the code for opening the Proposal Page
-        Window.alert("This is the " + selectedProposalId + " proposal");
+        presenter.goTo(new ExchangesPlace(selectedProposalId));
     }
 
     @Override

--- a/src/test/java/com/aadm/cardexchange/CardExchangeSuite.java
+++ b/src/test/java/com/aadm/cardexchange/CardExchangeSuite.java
@@ -29,6 +29,7 @@ import org.junit.platform.suite.api.Suite;
         AuthActivityTest.class,
         DecksActivityTest.class,
         NewExchangeActivityTest.class,
+        ExchangesActivityTest.class,
         AuthSubjectTest.class,
         AuthPayloadTest.class,
         DeckServiceTest.class,

--- a/src/test/java/com/aadm/cardexchange/client/ExchangesActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/ExchangesActivityTest.java
@@ -1,0 +1,39 @@
+package com.aadm.cardexchange.client;
+
+import com.aadm.cardexchange.client.auth.AuthSubject;
+import com.aadm.cardexchange.client.places.ExchangesPlace;
+import com.aadm.cardexchange.client.presenters.ExchangesActivity;
+import com.aadm.cardexchange.client.views.ExchangesView;
+import com.aadm.cardexchange.shared.ExchangeServiceAsync;
+import com.google.gwt.place.shared.Place;
+import com.google.gwt.place.shared.PlaceController;
+import org.easymock.IMocksControl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.easymock.EasyMock.*;
+
+public class ExchangesActivityTest {
+    IMocksControl ctrl;
+    ExchangesView mockView;
+    PlaceController mockPlaceController;
+    ExchangesActivity exchangesActivity;
+
+    @BeforeEach
+    public void initialize() {
+        ctrl = createStrictControl();
+        mockView = ctrl.createMock(ExchangesView.class);
+        ExchangeServiceAsync mockRpcService = ctrl.createMock(ExchangeServiceAsync.class);
+        mockPlaceController = ctrl.createMock(PlaceController.class);
+        exchangesActivity = new ExchangesActivity(mockView, mockRpcService, new AuthSubject(), mockPlaceController);
+    }
+
+    @Test
+    public void testForGoTo() {
+        mockPlaceController.goTo(isA(Place.class));
+        expectLastCall();
+        ctrl.replay();
+        exchangesActivity.goTo(new ExchangesPlace(1));
+        ctrl.verify();
+    }
+}


### PR DESCRIPTION
This PR implements #136 adding the navigation to the proposal detail page. For now, the NewExchangeView has been used, but maybe in the future it will be created another view to visualize the exchange proposal detail.

Coverage with unit testing has been done.