### PR TITLE
[UC14#141#142] Implemented dynamic handling of exchange buttons and card selection in 'wishedBy' userlist for improved UX

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/CardExchange.java
+++ b/src/main/java/com/aadm/cardexchange/client/CardExchange.java
@@ -84,6 +84,6 @@ public class CardExchange implements EntryPoint, Observer, ImperativeHandleSideb
 
     @Override
     public void update() {
-        appSidebar.setLinks(authSubject.isLoggedIn());
+        appSidebar.setLinks(authSubject.getEmail(), authSubject.isLoggedIn());
     }
 }

--- a/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/CardActivity.java
@@ -11,6 +11,7 @@ import com.aadm.cardexchange.shared.exceptions.AuthException;
 import com.aadm.cardexchange.shared.exceptions.InputException;
 import com.aadm.cardexchange.shared.models.Card;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithEmail;
+import com.aadm.cardexchange.shared.models.PhysicalCardWithEmailDealing;
 import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
@@ -45,14 +46,14 @@ public class CardActivity extends AbstractActivity implements CardView.Presenter
         view.setPresenter(this);
         containerWidget.setWidget(view.asWidget());
         fetchCard();
-        fetchOwnedPhysicalCards();
-        fetchWishedPhysicalCards();
         update();
     }
 
     @Override
     public void update() {
         view.createUserWidgets(authSubject.isLoggedIn());
+        fetchOwnedPhysicalCards();
+        fetchWishedPhysicalCards();
     }
 
     public void fetchCard() {
@@ -64,26 +65,35 @@ public class CardActivity extends AbstractActivity implements CardView.Presenter
         });
     }
 
+    private List<PhysicalCardWithEmail> filterOwnPhysicalCards(List<? extends PhysicalCardWithEmail> pCardsWithEmail) {
+        return pCardsWithEmail.stream().filter(pCardWithEmail -> !pCardWithEmail.getEmail().equals(authSubject.getEmail())).collect(Collectors.toList());
+    }
+
     private void fetchOwnedPhysicalCards() {
         deckService.getOwnedPhysicalCardsByCardId(place.getCardId(), new BaseAsyncCallback<List<PhysicalCardWithEmail>>() {
             @Override
             public void onSuccess(List<PhysicalCardWithEmail> result) {
-                view.setOwnedByUserList(
-                        authSubject.isLoggedIn() ?
-                                result.stream().filter(pCardWithEmail -> !pCardWithEmail.getEmail().equals(authSubject.getEmail())).collect(Collectors.toList()) :
-                                result
-                );
+                view.setOwnedByUserList(filterOwnPhysicalCards(result));
             }
         });
     }
 
     private void fetchWishedPhysicalCards() {
-        deckService.getWishedPhysicalCardsByCardId(place.getCardId(), new BaseAsyncCallback<List<PhysicalCardWithEmail>>() {
-            @Override
-            public void onSuccess(List<PhysicalCardWithEmail> result) {
-                view.setWishedByUserList(result);
-            }
-        });
+        if (authSubject.isLoggedIn()) {
+            deckService.getListPhysicalCardWithEmailDealing(authSubject.getToken(), place.getGame(), place.getCardId(), new BaseAsyncCallback<List<PhysicalCardWithEmailDealing>>() {
+                @Override
+                public void onSuccess(List<PhysicalCardWithEmailDealing> result) {
+                    view.setWishedByUserList(filterOwnPhysicalCards(result));
+                }
+            });
+        } else {
+            deckService.getWishedPhysicalCardsByCardId(place.getCardId(), new BaseAsyncCallback<List<PhysicalCardWithEmail>>() {
+                @Override
+                public void onSuccess(List<PhysicalCardWithEmail> result) {
+                    view.setWishedByUserList(filterOwnPhysicalCards(result));
+                }
+            });
+        }
     }
 
     public void addCardToDeck(String deckName, String status, String description) {

--- a/src/main/java/com/aadm/cardexchange/client/presenters/NewExchangeActivity.java
+++ b/src/main/java/com/aadm/cardexchange/client/presenters/NewExchangeActivity.java
@@ -51,7 +51,7 @@ public class NewExchangeActivity extends AbstractActivity implements NewExchange
         deckService.getMyDeck(authSubject.getToken(), "Owned", new BaseAsyncCallback<List<PhysicalCardWithName>>() {
             @Override
             public void onSuccess(List<PhysicalCardWithName> physicalCards) {
-                view.setSenderDeck(true, physicalCards, null, authSubject.getEmail());
+                view.setSenderDeck(true, physicalCards, place.getSelectedCardId(), authSubject.getEmail());
             }
         });
     }

--- a/src/main/java/com/aadm/cardexchange/client/views/CardView.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardView.java
@@ -18,7 +18,7 @@ public interface CardView extends IsWidget {
 
     void createUserWidgets(boolean isLoggedIn);
 
-    void setWishedByUserList(List<PhysicalCardWithEmail> pCards);
+    void setWishedByUserList(List<? extends PhysicalCardWithEmail> pCards);
 
     void setOwnedByUserList(List<PhysicalCardWithEmail> pCards);
 

--- a/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/CardViewImpl.java
@@ -13,6 +13,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Window;
@@ -127,14 +128,24 @@ public class CardViewImpl extends Composite implements CardView, ImperativeHandl
         userLists.add(wishedByUserList);
     }
 
-    @Override
-    public void setOwnedByUserList(List<PhysicalCardWithEmail> pCards) {
-        ownedByUserList.setTable(pCards, this);
+    public Button createWishedButton(PhysicalCardWithEmail pCard) {
+        if (pCard instanceof PhysicalCardWithEmailDealing && ((PhysicalCardWithEmailDealing) pCard).getIdPhysicalCardPawn() != null) {
+            return new Button("Exchange", (ClickHandler) e -> presenter.goTo(new NewExchangePlace(
+                    ((PhysicalCardWithEmailDealing) pCard).getIdPhysicalCardPawn(), pCard.getEmail())));
+        } else {
+            return null;
+        }
     }
 
     @Override
-    public void setWishedByUserList(List<PhysicalCardWithEmail> pCards) {
-        wishedByUserList.setTable(pCards, this);
+    public void setOwnedByUserList(List<PhysicalCardWithEmail> pCards) {
+        ownedByUserList.setTable(pCards, pCard -> new Button("Exchange", (ClickHandler) e ->
+                presenter.goTo(new NewExchangePlace(pCard.getId(), pCard.getEmail()))));
+    }
+
+    @Override
+    public void setWishedByUserList(List<? extends PhysicalCardWithEmail> pCards) {
+        wishedByUserList.setTable(pCards, this::createWishedButton);
     }
 
     @Override

--- a/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.java
@@ -3,6 +3,7 @@ package com.aadm.cardexchange.client.widgets;
 import com.aadm.cardexchange.client.handlers.ImperativeHandleSidebar;
 import com.aadm.cardexchange.client.routes.RouteConstants;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.ParagraphElement;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -12,6 +13,8 @@ public class SidebarWidget extends Composite implements RouteConstants {
     private static final SidebarUiBinder uiBinder = GWT.create(SidebarUiBinder.class);
     @UiField
     HTMLPanel links;
+    @UiField
+    ParagraphElement userEmail;
     Button button;
 
     public SidebarWidget(ImperativeHandleSidebar parent) {
@@ -20,8 +23,9 @@ public class SidebarWidget extends Composite implements RouteConstants {
         button.setStyleName("");
     }
 
-    public void setLinks(boolean isLoggedIn) {
+    public void setLinks(String email, boolean isLoggedIn) {
         links.clear();
+        userEmail.setInnerText(email != null ? "User: " + email : "");
         links.add(new Hyperlink("Home", homeLink));
         if (!isLoggedIn) {
             links.add(new Hyperlink("Auth", authLink));

--- a/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/SidebarWidget.ui.xml
@@ -14,6 +14,12 @@
             background: #20262E;
         }
 
+        .user {
+            position: absolute;
+            top: 1rem;
+            color: #fff;
+        }
+
         .sidebar > div, .sidebar > button {
             display: flex;
             justify-content: center;
@@ -41,5 +47,7 @@
             color: #f03a3a;
         }
     </ui:style>
-    <g:HTMLPanel styleName="{style.sidebar}" ui:field="links"/>
+    <g:HTMLPanel styleName="{style.sidebar}" ui:field="links">
+        <p class="{style.user}" ui:field="userEmail"/>
+    </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
@@ -1,11 +1,9 @@
 package com.aadm.cardexchange.client.widgets;
 
-import com.aadm.cardexchange.client.handlers.ImperativeHandleUserList;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithEmail;
 import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.*;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
@@ -15,15 +13,16 @@ import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class UserListWidget extends Composite {
     private static final UserListUIBinder uiBinder = GWT.create(UserListUIBinder.class);
-    private static final String NO_CARDS_TEXT = "No Cards";
+    private static final String NO_CARDS_TEXT = "No users";
     @UiField
     HeadingElement tableHeading;
     @UiField(provided = true)
     FlexTable table;
-    int noCardsRow;
+    int noUsersRow;
     boolean showExchangeButton;
 
     @UiConstructor
@@ -34,10 +33,10 @@ public class UserListWidget extends Composite {
         tableHeading.setInnerText(title);
     }
 
-    private void setNoCardsText() {
-        noCardsRow = table.getRowCount();
-        table.setText(noCardsRow, 0, NO_CARDS_TEXT);
-        table.getFlexCellFormatter().setColSpan(noCardsRow, 0, 3);
+    private void setNoUsersText() {
+        noUsersRow = table.getRowCount();
+        table.setText(noUsersRow, 0, NO_CARDS_TEXT);
+        table.getFlexCellFormatter().setColSpan(noUsersRow, 0, 3);
     }
 
     private void setupTable() {
@@ -46,16 +45,13 @@ public class UserListWidget extends Composite {
         TableRowElement row = tHead.insertRow(0);
         row.insertCell(0).setInnerText("User");
         row.insertCell(1).setInnerText("Status");
-        setNoCardsText();
+        setNoUsersText();
         if (showExchangeButton) row.insertCell(2).setInnerText("");
     }
 
-    public void setTable(List<PhysicalCardWithEmail> pCards, ImperativeHandleUserList parent) {
-        if (!pCards.isEmpty())
-            table.removeRow(noCardsRow);
-        pCards.forEach(pCard -> addRow(pCard.getEmail(), pCard.getStatus(), new Button(
-                "Exchange", (ClickHandler) event -> parent.onClickExchange(pCard.getEmail(), pCard.getId())
-        )));
+    public void setTable(List<? extends PhysicalCardWithEmail> pCards, Function<PhysicalCardWithEmail, Button> createButton) {
+        if (!pCards.isEmpty()) table.removeRow(noUsersRow);
+        pCards.forEach(pCard -> addRow(pCard.getEmail(), pCard.getStatus(), createButton.apply(pCard)));
     }
 
     private void addRow(String email, Status status, Button button) {

--- a/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
+++ b/src/main/java/com/aadm/cardexchange/server/services/ExchangeServiceImpl.java
@@ -56,6 +56,8 @@ public class ExchangeServiceImpl extends RemoteServiceServlet implements Exchang
                 db.getPersistentMap(getServletContext(), LOGIN_MAP_NAME, Serializer.STRING, new GsonSerializer<>(gson)));
         if (receiverUserEmail == null || receiverUserEmail.isEmpty() || !checkEmailExistence(receiverUserEmail))
             throw new InputException("Invalid receiver email");
+        if (email.equals(receiverUserEmail))
+            throw new InputException("You cannot propose an exchange with yourself.");
         if (!checkPhysicalCardsConsistency(senderPhysicalCards))
             throw new InputException("Invalid sender physical cards");
         if (!checkPhysicalCardsConsistency(receiverPhysicalCards))

--- a/src/test/java/com/aadm/cardexchange/client/CardActivityTest.java
+++ b/src/test/java/com/aadm/cardexchange/client/CardActivityTest.java
@@ -49,7 +49,8 @@ public class CardActivityTest {
     @Test
     public void testUpdate() {
         mockView.createUserWidgets(anyBoolean());
-        expectLastCall();
+        mockDeckService.getOwnedPhysicalCardsByCardId(anyInt(), isA(AsyncCallback.class));
+        mockDeckService.getWishedPhysicalCardsByCardId(anyInt(), isA(AsyncCallback.class));
         ctrl.replay();
         cardActivity.update();
         ctrl.verify();

--- a/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/ExchangeServiceTest.java
@@ -157,6 +157,20 @@ public class ExchangeServiceTest {
             ctrl.verify();
         }
 
+        @Test
+        public void testAddProposalForSameSenderAndReceiver() {
+            setupForValidToken();
+            Map<String, User> userMap = new HashMap<>();
+            userMap.put("test@test.it", new User("test@test.it", "password"));
+            expect(mockConfig.getServletContext()).andReturn(mockCtx);
+            expect(mockDB.getPersistentMap(isA(ServletContext.class), anyString(), isA(Serializer.class), isA(Serializer.class)))
+                    .andReturn(userMap);
+
+            ctrl.replay();
+            Assertions.assertThrows(InputException.class, () -> exchangeService.addProposal("validToken", "test@test.it", DummyData.createPhysicalCardDummyList(2), DummyData.createPhysicalCardDummyList(2)));
+            ctrl.verify();
+        }
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {"invalidToken"})


### PR DESCRIPTION
This PR implements #141, #142 and improves the user experience by dynamically handling the exchange buttons in the 'wishedBy' userlist. The exchange button is disabled when the logged in user does not have the desired card, avoiding unnecessary proposals. The logged in user's card is automatically selected in NewExchange page when clicking the exchange button in the 'wishedBy' userlist, streamlining the proposal process.
The email of the logged in user is added to the sidebar for better user understanding and for testing purposes.

This PR finishes the functionalities requested by the client. 🚀