### PR TITLE
[HOTFIX#193] Fixed acceptProposal RPC for not properly cleaning exchanged cards from custom decks

### DIFF
--- a/src/test/java/com/aadm/cardexchange/server/AcceptProposalTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/AcceptProposalTest.java
@@ -47,17 +47,22 @@ public class AcceptProposalTest {
         FakeDB fakeDB = new FakeDB(dummyProposalMap,
                 // deck map
                 new HashMap<>() {{
-                    Deck senderDeck = createDummyOwnedDeck();
-                    senderDeck.addPhysicalCard(dummySenderPhysicalCard);
-                    Deck receiverDeck = createDummyOwnedDeck();
-                    receiverDeck.addPhysicalCard(dummyReceiverPhysicalCard);
+                    Deck receiverOwnedDeck = createDummyOwnedDeck();
+                    Deck senderOwnedDeck = createDummyOwnedDeck();
+                    Deck receiverWishedDeck = new Deck("Wished", true);
+                    Deck receiverCustomDeck = new Deck("Custom", false);
+                    senderOwnedDeck.addPhysicalCard(dummySenderPhysicalCard);
+                    receiverOwnedDeck.addPhysicalCard(dummyReceiverPhysicalCard);
+                    receiverWishedDeck.addPhysicalCard(new PhysicalCard(dummySenderPhysicalCard.getGameType(), dummySenderPhysicalCard.getCardId(), Status.VeryDamaged, "Any card is fine"));
+                    receiverCustomDeck.addPhysicalCard(dummyReceiverPhysicalCard);
                     put("test@test.it", new LinkedHashMap<>() {{
-                        put("Owned", receiverDeck);
-//                        put("Wished", new Deck("Wished", true));
+                        put("Owned", receiverOwnedDeck);
+                        put("Wished", receiverWishedDeck);
+                        put("Custom", receiverCustomDeck);
                     }});
                     put("test2@test.it", new LinkedHashMap<>() {{
-                        put("Owned", senderDeck);
-//                        put("Wished", new Deck("Wished", true));
+                        put("Owned", senderOwnedDeck);
+                        put("Wished", new Deck("Wished", true));
                     }});
                 }});
         ExchangeServiceImpl exchangeService = new ExchangeServiceImpl(fakeDB);
@@ -73,6 +78,8 @@ public class AcceptProposalTest {
             Assertions.assertNull(fakeDB.getProposalMap().get(1));
             Assertions.assertTrue(fakeDB.getDeckMap().get("test@test.it").get("Owned").getPhysicalCards().stream().anyMatch(pCard -> pCard.equals(dummySenderPhysicalCard)));
             Assertions.assertTrue(fakeDB.getDeckMap().get("test2@test.it").get("Owned").getPhysicalCards().stream().anyMatch(pCard -> pCard.equals(dummyReceiverPhysicalCard)));
+            Assertions.assertTrue(fakeDB.getDeckMap().get("test@test.it").get("Wished").getPhysicalCards().isEmpty());
+            Assertions.assertTrue(fakeDB.getDeckMap().get("test@test.it").get("Custom").getPhysicalCards().isEmpty());
         });
     }
 

--- a/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
+++ b/src/test/java/com/aadm/cardexchange/server/DeckServiceTest.java
@@ -725,66 +725,6 @@ public class DeckServiceTest {
             });
             ctrl.verify();
         }
-
-        @Test
-        public void testRemovePhysicalCardsFromWishedDeckAfterExchangeForEmptyDeck() {
-            Deck emptyDeck = new Deck("empty");
-
-            ctrl.replay();
-            Deck actual = DeckServiceImpl.removePhysicalCardsFromWishedDecksAfterExchange(emptyDeck, new ArrayList<>());
-            Assertions.assertTrue(actual.getPhysicalCards().isEmpty());
-            ctrl.verify();
-        }
-
-        @Test
-        public void testRemovePhysicalCardsFromWishedDeckAfterExchangeForEmptyCards() {
-            Deck deck = new Deck("deck");
-            for (PhysicalCard pCard : DummyData.createPhysicalCardDummyList(5)) {
-                deck.addPhysicalCard(pCard);
-            }
-
-            ctrl.replay();
-            Deck actual = DeckServiceImpl.removePhysicalCardsFromWishedDecksAfterExchange(deck, new ArrayList<>());
-            Assertions.assertEquals(actual.getPhysicalCards().size(), deck.getPhysicalCards().size());
-            ctrl.verify();
-        }
-
-        @Test
-        public void testRemovePhysicalCardsFromWishedDeckAfterExchangeSuccess() {
-            // Wished Deck
-            PhysicalCard pCard1 = new PhysicalCard(Game.MAGIC, 111, Status.VeryDamaged, "This is a valid description.");
-            PhysicalCard pCard2 = new PhysicalCard(Game.MAGIC, 123, Status.Excellent, "This is a valid description.");
-            PhysicalCard pCard3 = new PhysicalCard(Game.MAGIC, 123, Status.Good, "This is a valid description.");        //Match
-            PhysicalCard pCard4 = new PhysicalCard(Game.MAGIC, 123, Status.VeryDamaged, "This is a valid description."); //Match
-
-            Deck wishedDeck = new Deck("Wished", true);
-            wishedDeck.addPhysicalCard(pCard1);
-            wishedDeck.addPhysicalCard(pCard2);
-            wishedDeck.addPhysicalCard(pCard3);
-            wishedDeck.addPhysicalCard(pCard4);
-
-            // setup cards list
-            List<PhysicalCard> listPhysicalCards = new ArrayList<>();
-            listPhysicalCards.add(new PhysicalCard(Game.MAGIC, 888, Status.randomStatus(), "This is a valid description."));
-            listPhysicalCards.add(new PhysicalCard(Game.MAGIC, 444, Status.Excellent, "This is a valid description."));
-            listPhysicalCards.add(pCard3);          //Match
-
-            ctrl.replay();
-            Deck actual = DeckServiceImpl.removePhysicalCardsFromWishedDecksAfterExchange(wishedDeck, listPhysicalCards);
-            ctrl.verify();
-
-            Status actualPCardStatus = null;
-            for (PhysicalCard pCard : actual.getPhysicalCards()) {
-                if (pCard.getCardId() == pCard3.getCardId())
-                    actualPCardStatus = pCard.getStatus();
-            }
-
-            Status finalActualPCardStatus = actualPCardStatus;
-            Assertions.assertAll(() -> {
-                Assertions.assertEquals(2, actual.getPhysicalCards().size());
-                Assertions.assertEquals(Status.Excellent, finalActualPCardStatus);
-            });
-        }
     }
 
     @Nested


### PR DESCRIPTION
This PR fixes the bug explained in issue #193. Also Refactored acceptProposal RPC for code cleanliness and moved decks updating to separate function `updateUserDecks`.