### PR TITLE
[HOTFIX#198] Fixed UX problem by displaying "No proposals" when no proposals are available in ProposalListWidget 

### DIFF
--- a/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
+++ b/src/main/java/com/aadm/cardexchange/client/views/NewExchangeViewImpl.java
@@ -126,8 +126,8 @@ public class NewExchangeViewImpl extends Composite implements NewExchangeView, I
 
     @Override
     public void onChangeSelection() {
-        acceptButton.setEnabled(receiverDeck != null && !receiverDeck.getDeckSelectedCards().isEmpty()
-                && senderDeck != null && !senderDeck.getDeckSelectedCards().isEmpty());
+        acceptButton.setEnabled(receiverDeck != null && receiverDeck.getDeckSelectedCards() != null && !receiverDeck.getDeckSelectedCards().isEmpty()
+                && senderDeck != null && senderDeck.getDeckSelectedCards() != null && !senderDeck.getDeckSelectedCards().isEmpty());
     }
 
     interface NewExchangeViewImplUIBinder extends UiBinder<Widget, NewExchangeViewImpl> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/BaseListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/BaseListWidget.java
@@ -1,0 +1,29 @@
+package com.aadm.cardexchange.client.widgets;
+
+import com.google.gwt.dom.client.*;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlexTable;
+
+public abstract class BaseListWidget extends Composite {
+    protected int noItemsRow;
+    @UiField
+    HeadingElement tableHeading;
+    @UiField(provided = true)
+    FlexTable table;
+
+    protected void setNoItemsText(String text) {
+        noItemsRow = table.getRowCount();
+        table.setText(noItemsRow, 0, text);
+        table.getFlexCellFormatter().setColSpan(noItemsRow, 0, 3);
+    }
+
+    protected void setupTable() {
+        table = new FlexTable();
+        TableSectionElement tHead = ((TableElement) ((Element) table.getElement())).createTHead();
+        TableRowElement row = tHead.insertRow(0);
+        setupTableHeader(row);
+    }
+
+    protected abstract void setupTableHeader(TableRowElement row);
+}

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
@@ -2,38 +2,35 @@ package com.aadm.cardexchange.client.widgets;
 
 import com.aadm.cardexchange.client.handlers.ImperativeHandleProposalList;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.*;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.TableRowElement;
 import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.Widget;
 
-public class ProposalListWidget extends Composite {
+public class ProposalListWidget extends BaseListWidget {
     private static final ProposalListUiBinder uiBinder = GWT.create(ProposalListUiBinder.class);
-    @UiField
-    HeadingElement tableHeading;
-    @UiField(provided = true)
-    FlexTable table;
+    private static final String NO_PROPOSALS_TEXT = "No proposals";
+    String otherUser;
 
     public ProposalListWidget(String title, String otherUser) {
-        setupTable(otherUser);
+        this.otherUser = otherUser;
+        setupTable();
         initWidget(uiBinder.createAndBindUi(this));
         tableHeading.setInnerText(title);
+        setNoItemsText(NO_PROPOSALS_TEXT);
     }
 
-    private void setupTable(String otherUser) {
-        table = new FlexTable();
-        TableSectionElement tHead = ((TableElement) ((Element) table.getElement())).createTHead();
-        TableRowElement row = tHead.insertRow(0);
+    @Override
+    protected void setupTableHeader(TableRowElement row) {
         row.insertCell(0).setInnerText("ID");
         row.insertCell(1).setInnerText("Date");
         row.insertCell(2).setInnerText(otherUser);
     }
 
     public void addRow(int id, String date, String email, ImperativeHandleProposalList rowClickHandler) {
+        if (table.getRowCount() == noItemsRow) table.removeRow(noItemsRow);
         int numRows = (table.getRowCount());
         table.setText(numRows, 0, String.valueOf(id));
         table.setText(numRows, 1, date);
@@ -50,6 +47,7 @@ public class ProposalListWidget extends Composite {
 
     public void resetTable() {
         table.removeAllRows();
+        setNoItemsText(NO_PROPOSALS_TEXT);
     }
 
     interface ProposalListUiBinder extends UiBinder<Widget, ProposalListWidget> {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.java
@@ -13,9 +13,11 @@ public class ProposalListWidget extends BaseListWidget {
     private static final ProposalListUiBinder uiBinder = GWT.create(ProposalListUiBinder.class);
     private static final String NO_PROPOSALS_TEXT = "No proposals";
     String otherUser;
+    int size;
 
     public ProposalListWidget(String title, String otherUser) {
         this.otherUser = otherUser;
+        this.size = 0;
         setupTable();
         initWidget(uiBinder.createAndBindUi(this));
         tableHeading.setInnerText(title);
@@ -30,7 +32,7 @@ public class ProposalListWidget extends BaseListWidget {
     }
 
     public void addRow(int id, String date, String email, ImperativeHandleProposalList rowClickHandler) {
-        if (table.getRowCount() == noItemsRow) table.removeRow(noItemsRow);
+        if (size++ == 0) table.removeRow(noItemsRow);
         int numRows = (table.getRowCount());
         table.setText(numRows, 0, String.valueOf(id));
         table.setText(numRows, 1, date);
@@ -47,6 +49,7 @@ public class ProposalListWidget extends BaseListWidget {
 
     public void resetTable() {
         table.removeAllRows();
+        size = 0;
         setNoItemsText(NO_PROPOSALS_TEXT);
     }
 

--- a/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/ProposalListWidget.ui.xml
@@ -14,7 +14,6 @@
             display: block;
             max-height: 60vh;
             overflow-y: scroll;
-            cursor: pointer;
         }
 
         .table::-webkit-scrollbar {
@@ -22,6 +21,7 @@
         }
 
         .table th, td {
+            text-align: center;
             padding: 0.2rem 1rem 0.2rem 0.7rem;
         }
 
@@ -35,6 +35,10 @@
             top: 0;
             background-color: rgb(205, 88, 136);
             font-weight: bold;
+        }
+
+        .table tbody > tr {
+            cursor: pointer;
         }
 
         .table thead td:first-child {

--- a/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
+++ b/src/main/java/com/aadm/cardexchange/client/widgets/UserListWidget.java
@@ -3,26 +3,18 @@ package com.aadm.cardexchange.client.widgets;
 import com.aadm.cardexchange.shared.models.PhysicalCardWithEmail;
 import com.aadm.cardexchange.shared.models.Status;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.*;
+import com.google.gwt.dom.client.TableRowElement;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
-import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 import java.util.function.Function;
 
-public class UserListWidget extends Composite {
+public class UserListWidget extends BaseListWidget {
     private static final UserListUIBinder uiBinder = GWT.create(UserListUIBinder.class);
-    private static final String NO_CARDS_TEXT = "No users";
-    @UiField
-    HeadingElement tableHeading;
-    @UiField(provided = true)
-    FlexTable table;
-    int noUsersRow;
+    private static final String NO_USERS_TEXT = "No users";
     boolean showExchangeButton;
 
     @UiConstructor
@@ -31,26 +23,18 @@ public class UserListWidget extends Composite {
         setupTable();
         initWidget(uiBinder.createAndBindUi(this));
         tableHeading.setInnerText(title);
+        setNoItemsText(NO_USERS_TEXT);
     }
 
-    private void setNoUsersText() {
-        noUsersRow = table.getRowCount();
-        table.setText(noUsersRow, 0, NO_CARDS_TEXT);
-        table.getFlexCellFormatter().setColSpan(noUsersRow, 0, 3);
-    }
-
-    private void setupTable() {
-        table = new FlexTable();
-        TableSectionElement tHead = ((TableElement) ((Element) table.getElement())).createTHead();
-        TableRowElement row = tHead.insertRow(0);
+    @Override
+    protected void setupTableHeader(TableRowElement row) {
         row.insertCell(0).setInnerText("User");
         row.insertCell(1).setInnerText("Status");
-        setNoUsersText();
         if (showExchangeButton) row.insertCell(2).setInnerText("");
     }
 
     public void setTable(List<? extends PhysicalCardWithEmail> pCards, Function<PhysicalCardWithEmail, Button> createButton) {
-        if (!pCards.isEmpty()) table.removeRow(noUsersRow);
+        if (!pCards.isEmpty()) table.removeRow(noItemsRow);
         pCards.forEach(pCard -> addRow(pCard.getEmail(), pCard.getStatus(), createButton.apply(pCard)));
     }
 


### PR DESCRIPTION
This PR addresses the UX issue described in issue #198 by adding a text placeholder when no data is present and refactoring the UserListWidget and ProposalListWidget to extend the BaseListWidget.
The BaseListWidget class was also added to eliminate duplicated code and provide common behavior such as handling the text for no data and adding a header to the table.